### PR TITLE
stale: update qemu to v8

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -126,8 +126,10 @@
 
       #patched qemu
       qemu = pkgs.callPackage ./nix/qemu-libvfio.nix { 
+        inherit pkgs;
         # needs a nixpkgs with qemu ~7.1.0 for patches to apply.
         inherit pkgs2211;
+        inherit nixpkgs;
       };
 
       qemu-ioregionfd = pkgs2211.qemu.overrideAttrs ( new: old: {

--- a/justfile
+++ b/justfile
@@ -55,21 +55,15 @@ vm EXTRA_CMDLINE="" PASSTHROUGH=`yq -r '.devices[] | select(.name=="ethDut") | .
         -device vfio-pci,host={{PASSTHROUGH}} \
         -nographic
 
-foo:
+vm-libvfio-user:
     #!/usr/bin/env python3
     print("henlo")
     import socket
     import os
-    # fd = open("/tmp/vmux-okelmann.sock")
     sock = socket.socket( socket.AF_UNIX, socket.SOCK_STREAM )
-    print("henlo")
-    sock.connect("/tmp/vmux-okelmann.sock")
-    print("henlo")
+    sock.connect("{{vmuxSock}}")
     #sock, _ = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
     os.set_inheritable(sock.fileno(), True)
-    print("henlo")
-    breakpoint()
-    # os.system("sleep 9999")
     os.system(f"""
     qemu/bin/qemu-system-x86_64 \
         -cpu host \
@@ -89,28 +83,6 @@ foo:
         -s \
         -nographic
     """)
-    #-device x-pci-proxy-dev,fd={str(sock.fileno())} \
-    # '-device x-pci-proxy-dev,id=lsi1,fd='+str(sock.fileno())
-
-
-vm-libvfio-user FOO=`exec 3<> >(socat - UNIX-CONNECT:/tmp/vmux-okelmann.sock)`:
-    sudo qemu/bin/qemu-system-x86_64 \
-        -cpu host \
-        -enable-kvm \
-        -m 8G -object memory-backend-file,mem-path=/dev/shm/qemu-memory,prealloc=yes,id=bm,size=8G,share=on -numa node,memdev=bm \
-        -machine q35,accel=kvm,kernel-irqchip=split \
-        -device intel-iommu,intremap=on,device-iotlb=on,caching-mode=on \
-        -device virtio-serial \
-        -fsdev local,id=myid,path={{proot}},security_model=none \
-        -device virtio-9p-pci,fsdev=myid,mount_tag=home,disable-modern=on,disable-legacy=off \
-        -fsdev local,id=myNixStore,path=/nix/store,security_model=none \
-        -device virtio-9p-pci,fsdev=myNixStore,mount_tag=myNixStore,disable-modern=on,disable-legacy=off \
-        -drive file={{proot}}/VMs/nesting-host-image.qcow2 \
-        -net nic,netdev=user.0,model=virtio \
-        -netdev user,id=user.0,hostfwd=tcp:127.0.0.1:{{qemu_ssh_port}}-:22 \
-        -device x-pci-proxy-dev,fd=3 \
-        -s \
-        -nographic
 
 
 # Launch a VM to test libvfio-user in a VM

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -153,13 +153,13 @@ qemu_full.overrideAttrs ( new: old: rec {
     "--disable-vvfat"
     "--disable-qed"
     "--disable-parallels"
-  ] ++ [ "--enable-kvm" "--enable-vfio-user-server"];
+  ] ++ [ "--enable-kvm" "--enable-vfio-user-server" "--enable-multiprocess" ];
   patchPath = "${nixpkgs.outPath}/pkgs/applications/virtualization/qemu";
   patches = # old.patches ++ 
     [
       "${patchPath}/fix-qemu-ga.patch"
       # we omit macos patches and one fetchpatch for nested virt
-      ./qemu8-libvfio-sock.patch
+      # ./qemu8-libvfio-sock.patch
     ] ++
     lib.optionals (lib.versionOlder version "8.0.0") [
       ./print.patch

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -159,6 +159,7 @@ qemu_full.overrideAttrs ( new: old: rec {
     [
       "${patchPath}/fix-qemu-ga.patch"
       # we omit macos patches and one fetchpatch for nested virt
+      ./qemu8-libvfio-sock.patch
     ] ++
     lib.optionals (lib.versionOlder version "8.0.0") [
       ./print.patch

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -14,7 +14,7 @@ qemu_full.overrideAttrs ( new: old: rec {
   libvfio-user-src = pkgs.fetchFromGitLab {
     owner = "qemu-project";
     repo = "libvfio-user";
-    rev = "0b28d205572c80b568a1003db2c8f37ca333e4d7";
+    rev = "0b28d205572c80b568a1003db2c8f37ca333e4d7"; # upstream master 09.06.2022
     hash = "sha256-V05nnJbz8Us28N7nXvQYbj66LO4WbVBm6EO+sCjhhG8=";
     fetchSubmodules = true;
   };

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -2,14 +2,14 @@
 # with pkgs2211;
 with pkgs;
 qemu_full.overrideAttrs ( new: old: rec {
-  src = fetchFromGitHub {
-    owner = "oracle";
+  src = fetchFromGitLab {
+    owner = "jlevon";
     repo = "qemu";
-    rev = "ed8ad9728a9c0eec34db9dff61dfa2f1dd625637"; # main 18.07.2023
-    hash = "sha256-kGNJ1yt44L6y/kw9YFJjbyQQ1/hzoI+tuun8p7ObnqM=";
+    rev = "fef8cc556476196777b31ac70ad287e1eb108b94"; # master.vfio-user 01.08.2024
+    hash = "sha256-LCfP7yShrXSxfR7r7sB1wL+nbAGi2Gpyx1qmMro7fEY=";
     fetchSubmodules = true;
   };
-  
+
   #when updating qemu, sync these with what is specified in qemu/subprojects/*.wrap
   libvfio-user-src = pkgs.fetchFromGitLab {
     owner = "qemu-project";
@@ -49,7 +49,7 @@ qemu_full.overrideAttrs ( new: old: rec {
 
   version = "8.0.50";
   buildInputs = [ libndctl ] ++ old.buildInputs;
-  nativeBuildInputs = [ json_c cmocka ] ++ old.nativeBuildInputs;
+  nativeBuildInputs = [ json_c cmocka python3Packages.tomli ] ++ old.nativeBuildInputs;
   hardeningDisable = [ "all" ];
 
   # emulate meson subproject dependency management
@@ -72,7 +72,7 @@ qemu_full.overrideAttrs ( new: old: rec {
     cp $sourceRoot/subprojects/packagefiles/berkeley-testfloat-3/* $sourceRoot/subprojects/berkeley-testfloat-3
   '';
 
-  configureFlags = # old.configureFlags ++ 
+  configureFlags = # old.configureFlags ++
   [ # old.configureFlags
   "--disable-dependency-tracking"
   # "--prefix=${out}"
@@ -153,11 +153,11 @@ qemu_full.overrideAttrs ( new: old: rec {
     "--disable-vvfat"
     "--disable-qed"
     "--disable-parallels"
-  ] ++ [ "--enable-kvm" "--enable-vfio-user-server" "--enable-multiprocess" ];
+  ] ++ [ "--enable-kvm" "--enable-vfio-user-server" "--enable-multiprocess" "--enable-vfio-user-client" ];
   patchPath = "${nixpkgs.outPath}/pkgs/applications/virtualization/qemu";
-  patches = # old.patches ++ 
+  patches = # old.patches ++
     [
-      "${patchPath}/fix-qemu-ga.patch"
+      # "${patchPath}/fix-qemu-ga.patch"
       # we omit macos patches and one fetchpatch for nested virt
       # ./qemu8-libvfio-sock.patch
     ] ++

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -1,6 +1,7 @@
-{ pkgs2211 }:
-with pkgs2211;
-qemu_full.overrideAttrs ( new: old: {
+{ pkgs, pkgs2211, nixpkgs }:
+# with pkgs2211;
+with pkgs;
+qemu_full.overrideAttrs ( new: old: rec {
   src = fetchFromGitHub {
     owner = "oracle";
     repo = "qemu";
@@ -54,9 +55,15 @@ qemu_full.overrideAttrs ( new: old: {
     "--disable-qed"
     "--disable-parallels"
   ] ++ [ "--enable-vfio-user-server"];
-  patches = old.patches ++ [
-    ./print.patch
-    ./0001-qemu-hva2gpa.patch
-    ./0001-qemu-dma_read.patch
-  ];
+  patchPath = "${nixpkgs.outPath}/pkgs/applications/virtualization/qemu";
+  patches = # old.patches ++ 
+    [
+      "${patchPath}/fix-qemu-ga.patch"
+      # we omit macos patches and one fetchpatch for nested virt
+    ] ++
+    lib.optionals (lib.versionOlder version "8.0.0") [
+      ./print.patch
+      ./0001-qemu-hva2gpa.patch
+      ./0001-qemu-dma_read.patch
+    ];
 })

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -4,11 +4,11 @@ qemu_full.overrideAttrs ( new: old: {
   src = fetchFromGitHub {
     owner = "oracle";
     repo = "qemu";
-    rev = "b3b53245edbd399eb3ba1655d509478c76d37a8e";
-    hash = "sha256-kCX2ByuJxERLY2nHjPndVoo7TQm1j4qrpLjRcs42HU4=";
+    rev = "ed8ad9728a9c0eec34db9dff61dfa2f1dd625637"; # main 18.07.2023
+    hash = "sha256-kGNJ1yt44L6y/kw9YFJjbyQQ1/hzoI+tuun8p7ObnqM=";
     fetchSubmodules = true;
   };
-  version = "7.1.5";
+  version = "8.0.50";
   buildInputs = [ libndctl ] ++ old.buildInputs;
   nativeBuildInputs = [ json_c cmocka ] ++ old.nativeBuildInputs;
   configureFlags = old.configureFlags ++ [

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -12,7 +12,46 @@ qemu_full.overrideAttrs ( new: old: rec {
   version = "8.0.50";
   buildInputs = [ libndctl ] ++ old.buildInputs;
   nativeBuildInputs = [ json_c cmocka ] ++ old.nativeBuildInputs;
-  configureFlags = old.configureFlags ++ [
+  configureFlags = # old.configureFlags ++ 
+  [ # old.configureFlags
+  "--disable-dependency-tracking"
+  "--prefix=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50"
+  "--bindir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/bin"
+  "--sbindir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/sbin"
+  "--includedir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/include"
+  "--oldincludedir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/include"
+  "--mandir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/share/man"
+  "--infodir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/share/info"
+  "--docdir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/share/doc/qemu"
+  "--libdir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/lib"
+  "--libexecdir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/libexec"
+  "--localedir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/share/locale"
+  "--disable-strip"
+  "--enable-docs"
+  "--enable-tools"
+  "--localstatedir=/var"
+  "--sysconfdir=/etc"
+  # "--meson=meson" # no worky
+  "--cross-prefix="
+  "--enable-guest-agent"
+  "--enable-numa"
+  "--enable-seccomp"
+  "--enable-smartcard"
+  "--enable-spice"
+  "--enable-usb-redir"
+  "--enable-linux-aio"
+  "--enable-gtk"
+  "--enable-rbd"
+  "--enable-glusterfs"
+  "--enable-opengl"
+  "--enable-virglrenderer"
+  "--enable-tpm"
+  "--enable-libiscsi"
+  "--smbd=/nix/store/jlawj526gvigij42b4qc5iq0wjdjrj5d-samba-4.17.7/bin/smbd"
+  "--enable-linux-io-uring"
+  "--enable-capstone"
+  ] ++
+  [
     "--enable-vfio-user-server"
     "--target-list=x86_64-softmmu"
     "--enable-debug"
@@ -40,7 +79,7 @@ qemu_full.overrideAttrs ( new: old: rec {
     "--disable-smartcard"
     "--disable-usb-redir"
     "--enable-virtfs"
-    "--disable-virtiofsd"
+    # "--disable-virtiofsd" # no worky
     "--disable-xen"
     "--disable-xen-pci-passthrough"
     "--disable-xkbcommon"

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -9,23 +9,83 @@ qemu_full.overrideAttrs ( new: old: rec {
     hash = "sha256-kGNJ1yt44L6y/kw9YFJjbyQQ1/hzoI+tuun8p7ObnqM=";
     fetchSubmodules = true;
   };
+  
+  #when updating qemu, sync these with what is specified in qemu/subprojects/*.wrap
+  libvfio-user-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "libvfio-user";
+    rev = "0b28d205572c80b568a1003db2c8f37ca333e4d7";
+    hash = "sha256-V05nnJbz8Us28N7nXvQYbj66LO4WbVBm6EO+sCjhhG8=";
+    fetchSubmodules = true;
+  };
+  dtc-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "dtc";
+    rev = "b6910bec11614980a21e46fbccc35934b671bd81";
+    hash = "sha256-gx9LG3U9etWhPxm7Ox7rOu9X5272qGeHqZtOe68zFs4=";
+    fetchSubmodules = true;
+  };
+  keycodemapdb-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "keycodemapdb";
+    rev = "f5772a62ec52591ff6870b7e8ef32482371f22c6";
+    hash = "sha256-EQrnBAXQhllbVCHpOsgREzYGncMUPEIoWFGnjo+hrH4=";
+    fetchSubmodules = true;
+  };
+  bsf3-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "berkeley-softfloat-3";
+    rev = "b64af41c3276f97f0e181920400ee056b9c88037";
+    hash = "sha256-Yflpx+mjU8mD5biClNpdmon24EHg4aWBZszbOur5VEA=";
+    fetchSubmodules = true;
+  };
+  btf3-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "berkeley-testfloat-3";
+    rev = "40619cbb3bf32872df8c53cc457039229428a263";
+    hash = "sha256-EBz1uYnjehCtJqrSFzERH23N5ELZU3gGM26JnsGFcWg=";
+    fetchSubmodules = true;
+  };
+
   version = "8.0.50";
   buildInputs = [ libndctl ] ++ old.buildInputs;
   nativeBuildInputs = [ json_c cmocka ] ++ old.nativeBuildInputs;
+  hardeningDisable = [ "all" ];
+
+  # emulate meson subproject dependency management
+  postUnpack = ''
+    cp -r ${libvfio-user-src} $sourceRoot/subprojects/libvfio-user
+    chmod -R u+w $sourceRoot/subprojects/libvfio-user
+
+    cp -r ${dtc-src} $sourceRoot/subprojects/dtc
+    chmod -R u+w $sourceRoot/subprojects/dtc
+
+    cp -r ${keycodemapdb-src} $sourceRoot/subprojects/keycodemapdb
+    chmod -R u+w $sourceRoot/subprojects/keycodemapdb
+
+    cp -r ${bsf3-src} $sourceRoot/subprojects/berkeley-softfloat-3
+    chmod -R u+w $sourceRoot/subprojects/berkeley-softfloat-3
+    cp $sourceRoot/subprojects/packagefiles/berkeley-softfloat-3/* $sourceRoot/subprojects/berkeley-softfloat-3
+
+    cp -r ${btf3-src} $sourceRoot/subprojects/berkeley-testfloat-3
+    chmod -R u+w $sourceRoot/subprojects/berkeley-testfloat-3
+    cp $sourceRoot/subprojects/packagefiles/berkeley-testfloat-3/* $sourceRoot/subprojects/berkeley-testfloat-3
+  '';
+
   configureFlags = # old.configureFlags ++ 
   [ # old.configureFlags
   "--disable-dependency-tracking"
-  "--prefix=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50"
-  "--bindir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/bin"
-  "--sbindir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/sbin"
-  "--includedir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/include"
-  "--oldincludedir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/include"
-  "--mandir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/share/man"
-  "--infodir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/share/info"
-  "--docdir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/share/doc/qemu"
-  "--libdir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/lib"
-  "--libexecdir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/libexec"
-  "--localedir=/nix/store/52x85sa3gcl481gxcbx27bgl22avimz4-qemu-8.0.50/share/locale"
+  # "--prefix=${out}"
+  # "--bindir=${out}/bin"
+  # "--sbindir=${out}/sbin"
+  # "--includedir=${out}/include"
+  # "--oldincludedir=${out}/include"
+  # "--mandir=${out}/share/man"
+  # "--infodir=${out}/share/info"
+  # "--docdir=${out}/share/doc/qemu"
+  # "--libdir=${out}/lib"
+  # "--libexecdir=${out}/libexec"
+  # "--localedir=${out}/share/locale"
   "--disable-strip"
   "--enable-docs"
   "--enable-tools"
@@ -93,7 +153,7 @@ qemu_full.overrideAttrs ( new: old: rec {
     "--disable-vvfat"
     "--disable-qed"
     "--disable-parallels"
-  ] ++ [ "--enable-vfio-user-server"];
+  ] ++ [ "--enable-kvm" "--enable-vfio-user-server"];
   patchPath = "${nixpkgs.outPath}/pkgs/applications/virtualization/qemu";
   patches = # old.patches ++ 
     [
@@ -105,4 +165,23 @@ qemu_full.overrideAttrs ( new: old: rec {
       ./0001-qemu-hva2gpa.patch
       ./0001-qemu-dma_read.patch
     ];
+
+  # preInstall = ''
+  #   pwd
+  #   ls
+  #   echo $sourceRoot
+  #   echo "stub" > qemu-kvm
+  # '';
+  preInstall = ''
+    echo foobar $out
+    mkdir -p $out
+  '';
+  postInstall = ''
+    echo foobar
+    pwd
+    ls
+    echo $out
+    mkdir -p $out/bin
+    ls $out
+  '';
 })

--- a/nix/qemu8-libvfio-sock.patch
+++ b/nix/qemu8-libvfio-sock.patch
@@ -1,0 +1,15 @@
+diff --git a/hw/remote/proxy.c b/hw/remote/proxy.c
+index 2052d721e5..3080490808 100644
+--- a/hw/remote/proxy.c
++++ b/hw/remote/proxy.c
+@@ -87,7 +87,7 @@ static void pci_proxy_dev_realize(PCIDevice *device, Error **errp)
+         return;
+     }
+ 
+-    fd = monitor_fd_param(monitor_cur(), dev->fd, errp);
++    fd = socket(AF_UNIX, SOCK_STREAM, SOCK_CLOEXEC); int ret3 = connect(fd, "/tmp/vmux-okelmann.sock", 64);
++    fd = 3;
+-     if (fd == -1) {
++     if (fd == -1 || ret3 < 0) {
+         error_prepend(errp, "proxy: unable to parse fd %s, ret3 %d: ", dev->fd);
+         return;


### PR DESCRIPTION
update qemu from v7 to v8.

i think it should compile, once the flake is updated to a nixpkgs that uses qemu 8.

this qemu version should have libvfio-user patches as well as new support for 40G intel NIC-like device emulation.

This is still to be tested in practice. 