### PR TITLE
Reformat vmux source

### DIFF
--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -1,118 +1,141 @@
-#include "util.hpp"
-#include "caps.hpp"
-#include "string.h"
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <stdio.h>
 
+#include "util.hpp"
+#include "caps.hpp"
+#include "string.h"
+
 extern "C" {
-  #include "libvfio-user.h"
-  #include "subprojects/libvfio-user/lib/private.h"
+#include "libvfio-user.h"
+#include "subprojects/libvfio-user/lib/private.h"
 }
 
-static void
-_log([[maybe_unused]] vfu_ctx_t *vfu_ctx, [[maybe_unused]] int level, char const *msg)
+static void _log([[maybe_unused]] vfu_ctx_t *vfu_ctx,
+        [[maybe_unused]] int level,
+        char const *msg)
 {
     fprintf(stderr, "capabilies[%d]: %s\n", getpid(), msg);
 }
 
-void Capabilities::map_header(std::string device) {
-  std::string config_path = "/sys/bus/pci/devices/" + device + "/config";
-  FILE *fd = fopen(config_path.c_str(), "rb");
-  if (fd == NULL)
-    die("Cannot open %s", config_path.c_str());
-  this->header_size = 4096; // PCI config headers can only be this big. Later we check if we can actually read this much
-  // For some reason we can't mmap this file, so we read it instad.
-  //this->header_mmap = mmap(NULL, this->header_size, PROT_READ, MAP_PRIVATE, fd, 0);
-  //if (this->header_mmap == MAP_FAILED)
-    //die("mmap failed");
-  if (this->header_mmap != NULL)
-    die("header_mmap has already been set");
-  this->header_mmap = malloc(this->header_size);
-  if (this->header_mmap == NULL)
-    die("malloc failed");
+void Capabilities::map_header(std::string device)
+{
+    std::string config_path = "/sys/bus/pci/devices/" + device + "/config";
+    FILE *fd = fopen(config_path.c_str(), "rb");
+    if (fd == NULL)
+        die("Cannot open %s", config_path.c_str());
+    this->header_size = 4096; // PCI config headers can only be this big. Later
+                              // we check if we can actually read this much For
+                              // some reason we can't mmap this file, so we
+                              // read it instad. this->header_mmap = mmap(NULL,
+                              // this->header_size, PROT_READ, MAP_PRIVATE, fd,
+                              // 0); if (this->header_mmap == MAP_FAILED)
+                              // die("mmap failed");
+    if (this->header_mmap != NULL)
+        die("header_mmap has already been set");
+    this->header_mmap = malloc(this->header_size);
+    if (this->header_mmap == NULL)
+        die("malloc failed");
 
-  size_t ret = fread(this->header_mmap, sizeof(char), this->header_size, fd);
-  if (ret != this->header_size && ret != 256)
-    die("only %zu bytes read", ret);
+    size_t ret = fread(this->header_mmap, sizeof(char), this->header_size, fd);
+    if (ret != this->header_size && ret != 256)
+        die("only %zu bytes read", ret);
 
-  fclose(fd);
+    fclose(fd);
 }
 
-Capabilities::~Capabilities() {
-  free(this->header_mmap);
-  free(this->vfu_ctx_stub->reg_info);
-  free(this->vfu_ctx_stub);
+Capabilities::~Capabilities()
+{
+    free(this->header_mmap);
+    free(this->vfu_ctx_stub->reg_info);
+    free(this->vfu_ctx_stub);
 }
 
-Capabilities::Capabilities(const vfio_region_info *config_info, std::string device) {
-  // set up a fake vfu_ctx. We dont actually do any libvfio-user stuff here,
-  // but just create a stub context so we can use libvfio-users pci capability
-  // parsing functionality.
-  this->vfu_ctx_stub = (vfu_ctx_t*) malloc(sizeof(vfu_ctx_t));
-  if (this->vfu_ctx_stub == NULL)
-    die("malloc failed");
-  memset(this->vfu_ctx_stub, 0, sizeof(vfu_ctx_t));
+Capabilities::Capabilities(const vfio_region_info *config_info,
+        std::string device)
+{
+    // set up a fake vfu_ctx. We dont actually do any libvfio-user stuff here,
+    // but just create a stub context so we can use libvfio-users pci
+    // capability parsing functionality.
+    this->vfu_ctx_stub = (vfu_ctx_t*) malloc(sizeof(vfu_ctx_t));
+    if (this->vfu_ctx_stub == NULL)
+        die("malloc failed");
+    memset(this->vfu_ctx_stub, 0, sizeof(vfu_ctx_t));
 
-  this->vfu_ctx_stub->reg_info = (vfu_reg_info_t*)malloc(VFU_PCI_DEV_NUM_REGIONS * sizeof(vfu_reg_info_t));
-  if (this->vfu_ctx_stub->reg_info == NULL)
-    die("malloc failed");
-  memset(this->vfu_ctx_stub->reg_info, 0, VFU_PCI_DEV_NUM_REGIONS * sizeof(vfu_reg_info_t));
+    this->vfu_ctx_stub->reg_info =
+        (vfu_reg_info_t*)malloc(VFU_PCI_DEV_NUM_REGIONS *
+                sizeof(vfu_reg_info_t));
+    if (this->vfu_ctx_stub->reg_info == NULL)
+        die("malloc failed");
+    memset(this->vfu_ctx_stub->reg_info, 0, VFU_PCI_DEV_NUM_REGIONS *
+            sizeof(vfu_reg_info_t));
 
-  int ret = vfu_setup_log(this->vfu_ctx_stub, _log, LOG_DEBUG);
-  if (ret < 0) {
-    die("failed to setup log");
-  }
+    int ret = vfu_setup_log(this->vfu_ctx_stub, _log, LOG_DEBUG);
+    if (ret < 0) {
+        die("failed to setup log");
+    }
 
-  this->map_header(device);
+    this->map_header(device);
 
-  this->vfu_ctx_stub->pci.config_space = (vfu_pci_config_space_t *)this->header_mmap;
+    this->vfu_ctx_stub->pci.config_space =
+        (vfu_pci_config_space_t *)this->header_mmap;
 
-  vfu_reg_info_t *config_info_stub = &(this->vfu_ctx_stub->reg_info[VFU_PCI_DEV_CFG_REGION_IDX]);
-  memset(config_info_stub, 0, sizeof(vfu_reg_info_t));
-  config_info_stub->size = config_info->size;
-  config_info_stub->offset = config_info->offset;
+    vfu_reg_info_t *config_info_stub =
+        &(this->vfu_ctx_stub->reg_info[VFU_PCI_DEV_CFG_REGION_IDX]);
+    memset(config_info_stub, 0, sizeof(vfu_reg_info_t));
+    config_info_stub->size = config_info->size;
+    config_info_stub->offset = config_info->offset;
 
-  if (config_info_stub->size != this->header_size && config_info_stub->size != 256)
-    die("Inconsistent pci config space size found");
+    if (config_info_stub->size != this->header_size
+            && config_info_stub->size != 256)
+        die("Inconsistent pci config space size found");
 }
 
 // allocates void pointer filled with cap_data sourced from a physical device
-void *Capabilities::capa(const char name[], int id, size_t size, bool extended) {
-  //return NULL;
-  size_t cap_offset = vfu_pci_find_next_capability(this->vfu_ctx_stub, extended, 0, id);
-  if (!cap_offset)
-    die("capability %s not found", name);
-  //size_t cap_size = cap_size( vfu_ctx, data, extended ); we rather set our own sizes
-  size_t cap_size = size;
-  void *cap_data = malloc(cap_size);
-  if (cap_data == NULL)
-    die("malloc failed");
-  memcpy(cap_data, (char*)this->header_mmap + cap_offset, cap_size);
-  printf("%s capability at offset %zu\n", name, cap_offset);
-  return cap_data;
+void *Capabilities::capa(const char name[], int id, size_t size, bool extended)
+{
+    // return NULL;
+    size_t cap_offset =
+        vfu_pci_find_next_capability(this->vfu_ctx_stub, extended, 0, id);
+    if (!cap_offset)
+        die("capability %s not found", name);
+    // size_t cap_size = cap_size( vfu_ctx, data, extended ); we rather set our
+    // own sizes
+    size_t cap_size = size;
+    void *cap_data = malloc(cap_size);
+    if (cap_data == NULL)
+        die("malloc failed");
+    memcpy(cap_data, (char*)this->header_mmap + cap_offset, cap_size);
+    printf("%s capability at offset %zu\n", name, cap_offset);
+    return cap_data;
 };
 
 void *Capabilities::dsn() {
-  return this->capa("device serial number (ext)", PCI_EXT_CAP_ID_DSN, PCI_EXT_CAP_DSN_SIZEOF, true);
+    return this->capa("device serial number (ext)", PCI_EXT_CAP_ID_DSN,
+            PCI_EXT_CAP_DSN_SIZEOF, true);
 };
 
 void *Capabilities::pm() {
-  return this->capa("power management", PCI_CAP_ID_PM, PCI_PM_SIZEOF, false);
+    return this->capa("power management", PCI_CAP_ID_PM, PCI_PM_SIZEOF, false);
 };
 
 void *Capabilities::msi() {
-  return this->capa("msi", PCI_CAP_ID_MSI, PCI_CAP_MSIX_SIZEOF, false); // can be longer?! Up to 0x18 long as per spec sec 7.7.1
+    // can be longer?! Up to 0x18 long as per spec sec 7.7.1
+    return this->capa("msi", PCI_CAP_ID_MSI, PCI_CAP_MSIX_SIZEOF, false);
 };
 
 void *Capabilities::msix() {
-  return this->capa("msix", PCI_CAP_ID_MSIX, PCI_CAP_MSIX_SIZEOF, false); // We dont copy tables here. But i think they are written by libvfio-user
+    // We dont copy tables here. But i think they are written by libvfio-user
+    return this->capa("msix", PCI_CAP_ID_MSIX, PCI_CAP_MSIX_SIZEOF, false);
 };
 
 void *Capabilities::exp() {
-  return this->capa("PCI Express (spec sec 6.5.3)", PCI_CAP_ID_EXP, 0x34, false); // slot registers at 0x34, ... and 0x3a are reserved
+    // slot registers at 0x34, ... and 0x3a are reserved
+    return this->capa("PCI Express (spec sec 6.5.3)",
+            PCI_CAP_ID_EXP, 0x34, false); 
 };
 
 void *Capabilities::vpd() {
-  return this->capa("vital product data", PCI_CAP_ID_VPD, PCI_CAP_VPD_SIZEOF, false);
+    return this->capa("vital product data",
+            PCI_CAP_ID_VPD, PCI_CAP_VPD_SIZEOF, false);
 };

--- a/src/caps.hpp
+++ b/src/caps.hpp
@@ -1,29 +1,33 @@
 #pragma once
+
 #include <string>
+
 extern "C" {
-  #include "libvfio-user.h"
+#include "libvfio-user.h"
 }
 
 class Capabilities {
-  public:
-    // Contains the pci config space of the passed-through device (underlying device). Does not contain any vfio-user context. Used to apply vfu functions to host config space.
-    vfu_ctx_t *vfu_ctx_stub;
+    public:
+        // Contains the pci config space of the passed-through device
+        // (underlying device). Does not contain any vfio-user context. Used to
+        // apply vfu functions to host config space.
+        vfu_ctx_t *vfu_ctx_stub;
 
-    ~Capabilities();
-    Capabilities(const vfio_region_info *config_info, std::string device);
+        Capabilities(const vfio_region_info *config_info, std::string device);
+        ~Capabilities();
 
-    void *capa(const char name[], int id, size_t size, bool extended);
-    void *dsn();
-    void *pm();
-    void *msi();
-    void *msix();
-    void *exp();
-    void *vpd();
+        void *capa(const char name[], int id, size_t size, bool extended);
+        void *dsn();
+        void *pm();
+        void *msi();
+        void *msix();
+        void *exp();
+        void *vpd();
 
-  private:
-    // copy of config space of underlying device
-    void *header_mmap = NULL;
-    size_t header_size;
+    private:
+        // copy of config space of underlying device
+        void *header_mmap = NULL;
+        size_t header_size;
 
-    void map_header(std::string device);
+        void map_header(std::string device);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <stdio.h>
 #include <stdlib.h>
 #include <err.h>
@@ -20,176 +21,183 @@
 #include <dirent.h>
 #include <set>
 #include <signal.h>
+#include <thread>
+
 #include "src/vfio-consumer.hpp"
 #include "src/util.hpp"
 #include "src/caps.hpp"
-#include <thread>
-
 #include "src/vfio-server.hpp"
 #include "src/util.hpp"
 #include "src/runner.hpp"
+
 extern "C" {
-  #include "libvfio-user.h"
+#include "libvfio-user.h"
 }
-
-
-
-#include <atomic>
 
 
 // set true by signals, should be respected by runtime loops
 std::atomic<bool> quit(false); 
 
 typedef struct {
-  uint64_t value[2];
-  void *bar1;
-  size_t bar1size;
+    uint64_t value[2];
+    void *bar1;
+    size_t bar1size;
 } vmux_dev_ctx_t;
 
+
 // keep as reference for now, how bar callback functions should work
-[[maybe_unused]] static ssize_t
-bar0_access(vfu_ctx_t *vfu_ctx, char * const buf, size_t count, __loff_t offset,
-            const bool is_write)
+[[maybe_unused]] static ssize_t bar0_access(
+        vfu_ctx_t *vfu_ctx,
+        char * const buf,
+        size_t count,
+        __loff_t offset,
+        const bool is_write
+        )
 {
-  vmux_dev_ctx_t *dev_ctx = (vmux_dev_ctx_t*)vfu_get_private(vfu_ctx);
+    vmux_dev_ctx_t *dev_ctx = (vmux_dev_ctx_t*)vfu_get_private(vfu_ctx);
 
-  if (count > sizeof(dev_ctx->value) || offset + count > sizeof(dev_ctx->value)) {
-    vfu_log(vfu_ctx, LOG_ERR, "bad BAR0 access %#llx-%#llx",
-            (unsigned long long)offset,
-            (unsigned long long)offset + count - 1);
-    errno = EINVAL;
-    return -1;
-  }
+    if (count > sizeof(dev_ctx->value)
+            || offset + count > sizeof(dev_ctx->value)) {
+        vfu_log(vfu_ctx, LOG_ERR, "bad BAR0 access %#llx-%#llx",
+                (unsigned long long)offset,
+                (unsigned long long)offset + count - 1);
+        errno = EINVAL;
+        return -1;
+    }
 
-  vfu_log(vfu_ctx, LOG_ERR, "BAR0 access :)");
-  if (is_write) {
-    memcpy((&dev_ctx->value) + offset, buf, count);
-  } else {
-    memcpy(buf, (&dev_ctx->value) + offset, count);
-  }
+    vfu_log(vfu_ctx, LOG_ERR, "BAR0 access :)");
+    if (is_write) {
+        memcpy((&dev_ctx->value) + offset, buf, count);
+    } else {
+        memcpy(buf, (&dev_ctx->value) + offset, count);
+    }
 
-  return count;
+    return count;
 }
-
 
 
 int _main(int argc, char** argv) {
 
-  int ch;
-  std::string device = "0000:18:00.0";
-  std::vector<std::string> devices; 
-  std::vector<VmuxRunner*> runner;
-  std::vector<VfioConsumer*> vfioc;
-  std::string group_arg;
-  //int HARDWARE_REVISION; // could be set by vfu_pci_set_class: vfu_ctx->pci.config_space->hdr.rid = 0x02;
-  std::vector<int> pci_ids;
-  std::vector<std::string> sockets;
-  while ((ch = getopt(argc,argv,"hd:s:")) != -1){
-    switch(ch)
-      {
-      case 'd':
-        devices.push_back(optarg);
-        break;
-      case 's':
-        sockets.push_back(optarg);
-        break;
-      case '?':
-      case 'h':
-        std::cout << "-d 0000:18:00.0                        PCI-Device\n"
-                  << "-s /tmp/vmux.sock                      Path of the socket\n";
-        return 0;
-      default:
-        break;
-      }
-  }
+    int ch;
+    std::string device = "0000:18:00.0";
+    std::vector<std::string> devices; 
+    std::vector<VmuxRunner*> runner;
+    std::vector<VfioConsumer*> vfioc;
+    std::string group_arg;
+    // int HARDWARE_REVISION; // could be set by vfu_pci_set_class:
+                              // vfu_ctx->pci.config_space->hdr.rid = 0x02;
+    std::vector<int> pci_ids;
+    std::vector<std::string> sockets;
+    while ((ch = getopt(argc,argv,"hd:s:")) != -1){
+        switch(ch)
+        {
+            case 'd':
+                devices.push_back(optarg);
+                break;
+            case 's':
+                sockets.push_back(optarg);
+                break;
+            case '?':
+            case 'h':
+                std::cout <<
+                    "-d 0000:18:00.0                        PCI-Device\n" <<
+                    "-s /tmp/vmux.sock                      Path of the socket"
+                    << "\n";
+                return 0;
+            default:
+                break;
+        }
+    }
 
-  if (sockets.size() == 0)
-    sockets.push_back("/tmp/vmux.sock");
-  
-  for(size_t i = 0; i < devices.size(); i++){
-    printf("Using: %s\n", devices[i].c_str());
-    vfioc.push_back(new VfioConsumer(devices[i].c_str()));
+    if (sockets.size() == 0)
+        sockets.push_back("/tmp/vmux.sock");
+
+    for(size_t i = 0; i < devices.size(); i++) {
+        printf("Using: %s\n", devices[i].c_str());
+        vfioc.push_back(new VfioConsumer(devices[i].c_str()));
+
+        if(vfioc[i]->init() < 0){
+            die("failed to initialize vfio consumer");
+        }
+        if (vfioc[i]->init_mmio() < 0) {
+            die("failed to initialize vfio mmio mappings");
+        }
+        vfioc[i]->init_legacy_irqs();
+        vfioc[i]->init_msix();
+    }
+    //return 0;
+
+    int efd = epoll_create1(0);
+
+    for(size_t i = 0; i < devices.size(); i++){
+        printf("Using: %s\n", devices[i].c_str());
+        runner.push_back(new VmuxRunner(sockets[i], devices[i], *vfioc[i], efd));
+        runner[i]->start();
+
+        while(runner[i]->state !=2);
+    }
+
+
+    //VmuxRunner r(socket,device);
+    //r.start();
+    for(size_t i = 0; i < devices.size(); i++){
+        while(!runner[i]->is_connected()){
+            if(quit.load())
+                break;
+            usleep(10000);
+        }
+    }
+    // printf("pfd->revents & POLLIN: %d\n",
+    //        runner[0]->get_interrupts().pollfds[
+    //            runner[0]->get_interrupts().irq_intx_pollfd_idx
+    //            ].revents & POLLIN);
     
-    if(vfioc[i]->init() < 0){
-        die("failed to initialize vfio consumer");
+    // runtime loop
+    while (!quit.load()) {
+        for(size_t i = 0; i < runner.size(); i++){
+            struct epoll_event events[1024];
+
+            int eventsc = epoll_wait(efd, events, 1024,500);
+
+            for(int i = 0; i < eventsc; i++){
+                auto f = (interrupt_callback*)events[i].data.ptr;
+                f->callback(f->fd,f->vfu);
+            }
+        }
     }
-    if (vfioc[i]->init_mmio() < 0) {
-        die("failed to initialize vfio mmio mappings");
+
+    for(size_t i = 0; i < devices.size(); i++){
+        runner[i]->stop();
     }
-    vfioc[i]->init_legacy_irqs();
-    vfioc[i]->init_msix();
-  }
-  //return 0;
-  
-  int efd = epoll_create1(0);
-
-
-  for(size_t i = 0; i < devices.size(); i++){
-    printf("Using: %s\n", devices[i].c_str());
-    runner.push_back(new VmuxRunner(sockets[i], devices[i], *vfioc[i], efd));
-    
-    runner[i]->start();
-     
-    while(runner[i]->state !=2);
-    
-  }
-
-
-  //VmuxRunner r(socket,device);
-  //r.start();
-  for(size_t i = 0; i < devices.size(); i++){
-    while(!runner[i]->is_connected()){
-      if(quit.load())
-        break;
-      usleep(10000);
+    for(size_t i = 0; i < devices.size(); i++){
+        runner[i]->join();
     }
-  }
-  //printf("pfd->revents & POLLIN: %d\n", runner[0]->get_interrupts().pollfds[runner[0]->get_interrupts().irq_intx_pollfd_idx].revents & POLLIN);
-  ///
-  // runtime loop
-  while (!quit.load()) {
-    for(size_t i = 0; i < runner.size(); i++){
-      struct epoll_event events[1024];
 
-      int eventsc = epoll_wait(efd, events, 1024,500);
-
-      for(int i = 0; i < eventsc; i++){
-        auto f = (interrupt_callback*)events[i].data.ptr;
-        f->callback(f->fd,f->vfu);
-      }
-    }
-  }
-
-  for(size_t i = 0; i < devices.size(); i++){
-    runner[i]->stop();
-  }
-  for(size_t i = 0; i < devices.size(); i++){
-    runner[i]->join();
-  }
-  // destruction is done by ~VfioUserServer
-  close(efd);
-  return 0;
+    // destruction is done by ~VfioUserServer
+    close(efd);
+    return 0;
 }
+
 
 void signal_handler(int) {
-  quit.store(true);
+    quit.store(true);
 }
+
 
 int main(int argc, char** argv) {
-  // register signal handler to handle SIGINT gracefully to call destructors
-  struct sigaction sa;
-  memset(&sa, 0, sizeof(sa));
-  sa.sa_handler = signal_handler;
-  sigfillset(&sa.sa_mask);
-  sigaction(SIGINT, &sa, NULL);
+    // register signal handler to handle SIGINT gracefully to call destructors
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = signal_handler;
+    sigfillset(&sa.sa_mask);
+    sigaction(SIGINT, &sa, NULL);
 
-  try {
-    return _main(argc, argv);
-  } catch (...) {
-    // we seem to need this catch everyting so that our destructors work
-    return EXIT_FAILURE;
-  }
+    try {
+        return _main(argc, argv);
+    } catch (...) {
+        // we seem to need this catch everyting so that our destructors work
+        return EXIT_FAILURE;
+    }
 
-  return quit;
+    return quit;
 }
-

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -1,31 +1,34 @@
 #include "src/runner.hpp"
 
-#define stop_runner(s,str, ...) do{ \
-    state.store(s);             \
-    printf(str,__VA_ARGS__);        \
-    return;                     \
-}while(0)
 
-static void
-_log([[maybe_unused]] vfu_ctx_t *vfu_ctx, [[maybe_unused]] int level, char const *msg)
+#define stop_runner(s,str, ...) do { \
+    state.store(s);                  \
+    printf(str,__VA_ARGS__);         \
+    return;                          \
+} while(0)
+
+
+static void _log([[maybe_unused]] vfu_ctx_t *vfu_ctx,
+        [[maybe_unused]] int level, char const *msg)
 {
     fprintf(stderr, "server[%d]: %s\n", getpid(), msg);
 }
 
-void VmuxRunner::run(){
-    
+
+void VmuxRunner::run()
+{
     this->initilize();
     state.store(INITILIZED);
     printf("%s: Waiting for qemu to attach...\n",this->device.data());
     while(1){
         int ret = vfu_attach_ctx(vfu.vfu_ctx);
         if (ret < 0) {
-        usleep(10000);
+            usleep(10000);
 
-        if(!running.load()){
-            break;
-        }
-        continue;
+            if(!running.load()){
+                break;
+            }
+            continue;
         }
         break;
     }   
@@ -33,20 +36,20 @@ void VmuxRunner::run(){
 
     struct pollfd pfd = (struct pollfd) {
         .fd = vfu_get_poll_fd(vfu.vfu_ctx),
-        .events = POLLIN
+            .events = POLLIN
     };
 
-    while(running.load()){
+    while(running.load()) {
         int ret = poll(&pfd, 1, 500);
-        
+
         if (pfd.revents & POLLIN) {
             ret = vfu_run_ctx(vfu.vfu_ctx);
             if (ret < 0) {
                 if (errno == EAGAIN) {
-                continue;
+                    continue;
                 }
                 if (errno == ENOTCONN) {
-                die("vfu_run_ctx() does not want to run anymore");
+                    die("vfu_run_ctx() does not want to run anymore");
                 }
                 // perhaps is there also an ESHUTDOWN case?
                 die("vfu_run_ctx() failed (to realize device emulation)");
@@ -56,6 +59,7 @@ void VmuxRunner::run(){
 
 
 }
+
 
 void VmuxRunner::initilize(){
     std::vector<int> pci_ids;
@@ -70,13 +74,18 @@ void VmuxRunner::initilize(){
     //Get Hardware Information from Device
     pci_ids = get_hardware_ids(device,group_arg);
     if(pci_ids.size() != 5){
-        die("Failed to parse Hardware Information, expected %d IDs got %zu\n",5,pci_ids.size());
-        //stop_runner(-1,"Failed to parse Hardware Information, expected %d IDs got %zu\n",5,pci_ids.size());
+        die("Failed to parse Hardware Information, expected %d IDs got %zu\n",
+                5, pci_ids.size());
+        // stop_runner(-1,
+        // "Failed to parse Hardware Information, expected %d IDs got %zu\n",
+        // 5, pci_ids.size());
     }
     HARDWARE_REVISION = pci_ids[0];
-    pci_ids.erase(pci_ids.begin()); //Only contains Vendor ID, Device ID, Subsystem Vendor ID, Subsystem ID now
+    pci_ids.erase(pci_ids.begin()); // Only contains Vendor ID, Device ID,
+                                    // Subsystem Vendor ID, Subsystem ID now
 
-    printf("PCI-Device: %s\nIOMMU-Group: %s\nRevision: 0x%02X\nIDs: 0x%04X,0x%04X,0x%04X,0x%04X\nSocket: %s\n",
+    printf("PCI-Device: %s\nIOMMU-Group: %s\nRevision: 0x%02X\n\
+            IDs: 0x%04X,0x%04X,0x%04X,0x%04X\nSocket: %s\n",
             device.c_str(),
             group_arg.c_str(),
             HARDWARE_REVISION,
@@ -86,30 +95,32 @@ void VmuxRunner::initilize(){
 
     printf("%s", vfu.sock.c_str());
     vfu.vfu_ctx = vfu_create_ctx(
-        VFU_TRANS_SOCK,
-        vfu.sock.c_str(),
-        LIBVFIO_USER_FLAG_ATTACH_NB,
-        &vfu,
-        VFU_DEV_TYPE_PCI
-    );
-    
+            VFU_TRANS_SOCK,
+            vfu.sock.c_str(),
+            LIBVFIO_USER_FLAG_ATTACH_NB,
+            &vfu,
+            VFU_DEV_TYPE_PCI
+            );
+
     if (vfu.vfu_ctx == NULL) {
         die("failed to initialize device emulation");
     }
-    
+
     int ret = vfu_setup_log(vfu.vfu_ctx, _log, LOG_DEBUG);
     if (ret < 0) {
         die("failed to setup log");
     }
 
     ret = vfu_pci_init(vfu.vfu_ctx, VFU_PCI_TYPE_EXPRESS,
-                        PCI_HEADER_TYPE_NORMAL, 0); // maybe 4?
+            PCI_HEADER_TYPE_NORMAL, 0); // maybe 4?
     if (ret < 0) {
         die("vfu_pci_init() failed") ;
     }
 
-    vfu_pci_set_id(vfu.vfu_ctx, pci_ids[0], pci_ids[1], pci_ids[2], pci_ids[3]);
-    vfu_pci_config_space_t *config_space = vfu_pci_get_config_space(vfu.vfu_ctx);
+    vfu_pci_set_id(vfu.vfu_ctx, pci_ids[0], pci_ids[1],
+            pci_ids[2], pci_ids[3]);
+    vfu_pci_config_space_t *config_space =
+        vfu_pci_get_config_space(vfu.vfu_ctx);
     config_space->hdr.rid = HARDWARE_REVISION;
     vfu_pci_set_class(vfu.vfu_ctx, 0x02, 0x00, 0x00);
 
@@ -125,9 +136,10 @@ void VmuxRunner::initilize(){
     if (ret < 0)
         die("failed to add irqs");
 
-    vfu.add_legacy_irq_pollfds(vfioc.irqfd_intx, vfioc.irqfd_msi, vfioc.irqfd_err, vfioc.irqfd_req);
+    vfu.add_legacy_irq_pollfds(vfioc.irqfd_intx, vfioc.irqfd_msi,
+            vfioc.irqfd_err, vfioc.irqfd_req);
     vfu.add_msix_pollfds(vfioc.irqfds);
-    
+
     if(vfioc.is_pcie){
         this->add_caps();
     }
@@ -140,65 +152,72 @@ void VmuxRunner::initilize(){
     }
 }
 
+
 void VmuxRunner::add_caps(){
-    Capabilities caps = Capabilities(&(vfioc.regions[VFU_PCI_DEV_CFG_REGION_IDX]), device);
+    Capabilities caps =
+        Capabilities(&(vfioc.regions[VFU_PCI_DEV_CFG_REGION_IDX]), device);
     void *cap_data;
 
     cap_data = caps.pm();
     int ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, 0, cap_data);
     if (ret < 0)
-    die("add cap error");
+        die("add cap error");
     free(cap_data);
 
     cap_data = caps.msix();
     ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, 0, cap_data);
     if (ret < 0)
-    die("add cap error");
+        die("add cap error");
     free(cap_data);
 
     // not supported by libvfio-user:
-    //cap_data = caps.msi();
-    //ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, VFU_CAP_FLAG_READONLY, cap_data);
-    //if (ret < 0)
-    //  die("add cap error");
-    //free(cap_data);
-    
+    // cap_data = caps.msi();
+    // ret = vfu_pci_add_capability(vfu.vfu_ctx, 0,
+    //   VFU_CAP_FLAG_READONLY, cap_data);
+    // if (ret < 0)
+    //   die("add cap error");
+    // free(cap_data);
+
     cap_data = caps.exp();
-    ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, VFU_CAP_FLAG_READONLY, cap_data);
+    ret = vfu_pci_add_capability(vfu.vfu_ctx, 0,
+            VFU_CAP_FLAG_READONLY, cap_data);
     if (ret < 0)
-    die("add cap error");
+        die("add cap error");
     free(cap_data);
 
     // not supported by upstream libvfio-user, not used by linux ice driver
-    //cap_data = caps.vpd();
-    //ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, VFU_CAP_FLAG_READONLY, cap_data);
-    //if (ret < 0)
-    //  die("add cap error");
-    //free(cap_data);
-    
+    // cap_data = caps.vpd();
+    // ret = vfu_pci_add_capability(vfu.vfu_ctx, 0,
+    //   VFU_CAP_FLAG_READONLY, cap_data);
+    // if (ret < 0)
+    //   die("add cap error");
+    // free(cap_data);
+
     cap_data = caps.dsn();
-    ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, VFU_CAP_FLAG_READONLY | VFU_CAP_FLAG_EXTENDED, cap_data);
+    ret = vfu_pci_add_capability(vfu.vfu_ctx, 0,
+            VFU_CAP_FLAG_READONLY | VFU_CAP_FLAG_EXTENDED, cap_data);
     if (ret < 0)
-    die("add cap error");
+        die("add cap error");
     free(cap_data);
 
-    // see lspci about which fields mean what https://github.com/pciutils/pciutils/blob/42e6a803bda392e98276b71994db0b0dd285cab1/ls-caps.c#L1469
-    //struct msixcap data;
-    //data.hdr = {
-    //  .id = PCI_CAP_ID_MSIX,
-    //};
-    //data.mxc = {
-    //  // message control
-    //};
-    //data.mtab = {
-    //  // table offset / Table BIR
-    //};
-    //data.mpba = {
-    //  // PBA offset / PBA BIR
-    //};
-    ////ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, 0, &data);
-    //if (ret < 0) {
-    //  die("Vfio-user: cannot add MSIX capability");
-    //}
+    // see lspci about which fields mean what
+    // https://github.com/pciutils/pciutils/blob/42e6a803bda392e98276b71994db0b0dd285cab1/ls-caps.c#L1469
+    // struct msixcap data;
+    // data.hdr = {
+    //   .id = PCI_CAP_ID_MSIX,
+    // };
+    // data.mxc = {
+    //   // message control
+    // };
+    // data.mtab = {
+    //   // table offset / Table BIR
+    // };
+    // data.mpba = {
+    //   // PBA offset / PBA BIR
+    // };
+    // //ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, 0, &data);
+    // if (ret < 0) {
+    //   die("Vfio-user: cannot add MSIX capability");
+    // }
     this->caps = caps;
 }

--- a/src/runner.hpp
+++ b/src/runner.hpp
@@ -1,62 +1,62 @@
 #pragma once
-#include "src/vfio-server.hpp"
+
 #include <thread>
 #include <atomic>
 #include <optional>
+#include "src/vfio-server.hpp"
+
+
 class VmuxRunner{
-
     public: 
-    VfioUserServer vfu;
-    VfioConsumer& vfioc;
-    std::thread runner;
-    std::optional<Capabilities> caps;
-    std::atomic_int state;
-    std::atomic_bool running;
-    std::string device;
-    std::string socket;
-    //void (*VmuxRunner::interrupt_handler)(void);
+        VfioUserServer vfu;
+        VfioConsumer& vfioc;
+        std::thread runner;
+        std::optional<Capabilities> caps;
+        std::atomic_int state;
+        std::atomic_bool running;
+        std::string device;
+        std::string socket;
 
-    enum State{
-        NOT_STARTED = 0,
-        STARTED = 1,
-        INITILIZED = 2,
-        CONNECTED = 3,
-    };
+        //void (*VmuxRunner::interrupt_handler)(void);
 
-    VmuxRunner(std::string socket, std::string device, VfioConsumer& vfioc, int efd):
-        vfu(socket,efd),vfioc(vfioc)
-    {
-        state.store(0);
-        this->device = device;
-        this->socket = socket;
-    }
-        
-    void start(){
-        runner = std::thread(&VmuxRunner::run, this);
-    }
+        enum State{
+            NOT_STARTED = 0,
+            STARTED = 1,
+            INITILIZED = 2,
+            CONNECTED = 3,
+        };
 
-    void stop(){
-        running.store(0);
-    }
-    
-    void join(){
-        runner.join();
-    }
+        VmuxRunner(std::string socket, std::string device, VfioConsumer& vfioc,
+                int efd): vfu(socket,efd), vfioc(vfioc) {
+            state.store(0);
+            this->device = device;
+            this->socket = socket;
+        }
 
-    bool is_initialized(){
-        return state == INITILIZED;
-    }
-    bool is_connected(){
-        return state == CONNECTED;
-    }
-    VfioUserServer& get_interrupts(){
-        return vfu;
-    }
+        void start(){
+            runner = std::thread(&VmuxRunner::run, this);
+        }
+
+        void stop(){
+            running.store(0);
+        }
+
+        void join(){
+            runner.join();
+        }
+
+        bool is_initialized(){
+            return state == INITILIZED;
+        }
+        bool is_connected(){
+            return state == CONNECTED;
+        }
+        VfioUserServer& get_interrupts(){
+            return vfu;
+        }
 
     private:
-    void run();
-    void add_caps();
-    void initilize();
-
-
+        void run();
+        void add_caps();
+        void initilize();
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,55 +5,62 @@
 
 
 std::string get_iommu_group(std::string pci_device){
-  std::string path = "/sys/kernel/iommu_groups/";
-  struct dirent *iommu_group;
-  DIR *iommu_dir = opendir(path.c_str());
-  if (iommu_dir == NULL){
-          return "";
-  }
-  while((iommu_group = readdir(iommu_dir)) != NULL) {
-    if(strcmp(iommu_group->d_name,".") != 0 && strcmp(iommu_group->d_name,"..") != 0){
-      std::string iommu_group_str = iommu_group->d_name;
-      struct dirent *iommu_group_dir;
-      DIR *pci = opendir((path + iommu_group->d_name + "/devices").c_str());
-      while((iommu_group_dir = readdir(pci)) != NULL){
-        if(pci_device == iommu_group_dir->d_name){
-          closedir(pci);
-          closedir(iommu_dir);
-          return iommu_group_str;
-        }
-      }
-      closedir(pci);
+    std::string path = "/sys/kernel/iommu_groups/";
+    struct dirent *iommu_group;
+    DIR *iommu_dir = opendir(path.c_str());
+    if (iommu_dir == NULL){
+        return "";
     }
-  }
-  closedir(iommu_dir);
-  return "";
+    while((iommu_group = readdir(iommu_dir)) != NULL) {
+        if(strcmp(iommu_group->d_name,".") != 0 &&
+                strcmp(iommu_group->d_name,"..") != 0){
+            std::string iommu_group_str = iommu_group->d_name;
+            struct dirent *iommu_group_dir;
+            DIR *pci =
+                opendir((path + iommu_group->d_name + "/devices").c_str());
+            while((iommu_group_dir = readdir(pci)) != NULL){
+                if(pci_device == iommu_group_dir->d_name){
+                    closedir(pci);
+                    closedir(iommu_dir);
+                    return iommu_group_str;
+                }
+            }
+            closedir(pci);
+        }
+    }
+    closedir(iommu_dir);
+    return "";
 }
 
-std::vector<int>  get_hardware_ids(std::string pci_device,std::string iommu_group){
-  std::string path = "/sys/kernel/iommu_groups/" + iommu_group +"/devices/" + pci_device + "/";
-  std::vector<std::string> values = {"revision", "vendor", "device", "subsystem_vendor", "subsystem_device"};
-  std::vector<int> result;
-  int bytes_read;
-  char id_buffer[7];
-  FILE* id;
-  
-  for(size_t i = 0; i < values.size(); i++ ){
-    id = fopen((path + values[i]).c_str(), "r");
-    if(id == NULL){
-      result.clear();
-      printf("Failed ot open %s\n",(path + values[i]).c_str());
-      return result;
-    }
-    bytes_read = fread(id_buffer, 1, sizeof(id_buffer) / sizeof(id_buffer[0]) - 1, id);
-    if(bytes_read < 1){
-      result.clear();
-      printf("Failed to read %s, got %s\n", values[i].c_str(),id_buffer);
-      return result;
-    }
-    result.push_back((int)strtol(id_buffer,NULL,0));
-    fclose(id);
-  }   
+std::vector<int> get_hardware_ids(std::string pci_device,
+        std::string iommu_group)
+{
+    std::string path = "/sys/kernel/iommu_groups/"
+        + iommu_group +"/devices/" + pci_device + "/";
+    std::vector<std::string> values = {"revision", "vendor", "device",
+        "subsystem_vendor", "subsystem_device"};
+    std::vector<int> result;
+    int bytes_read;
+    char id_buffer[7];
+    FILE* id;
 
-  return result;
+    for(size_t i = 0; i < values.size(); i++ ){
+        id = fopen((path + values[i]).c_str(), "r");
+        if(id == NULL){
+            result.clear();
+            printf("Failed ot open %s\n",(path + values[i]).c_str());
+            return result;
+        }
+        bytes_read = fread(id_buffer, 1, sizeof(id_buffer) /
+                sizeof(id_buffer[0]) - 1, id);
+        if(bytes_read < 1){
+            result.clear();
+            printf("Failed to read %s, got %s\n", values[i].c_str(),id_buffer);
+            return result;
+        }
+        result.push_back((int)strtol(id_buffer,NULL,0));
+        fclose(id);
+    }   
+
+    return result;
 }

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <stdexcept>
@@ -13,10 +12,11 @@
 // exit() and err() breaks invariants for RAII (destructors). Therefore we use
 // warn() instead to printf an error and throw afterwards to exit.
 #define die(...) { \
-  warn(__VA_ARGS__); \
-  throw std::runtime_error("See error above"); \
-  }
-
+    warn(__VA_ARGS__); \
+    throw std::runtime_error("See error above"); \
+}
 
 std::string get_iommu_group(std::string pci_device);
-std::vector<int>  get_hardware_ids(std::string pci_device,std::string iommu_group);
+
+std::vector<int> get_hardware_ids(std::string pci_device,
+        std::string iommu_group);

--- a/src/vfio-consumer.cpp
+++ b/src/vfio-consumer.cpp
@@ -16,350 +16,378 @@
 
 #include "src/util.hpp"
 
+
 VfioConsumer::VfioConsumer(std::string group_str, std::string device_name){
-  this->group_str = "/dev/vfio/" + group_str;
-  this->device_name = device_name;
+    this->group_str = "/dev/vfio/" + group_str;
+    this->device_name = device_name;
 }
 
+
 VfioConsumer::VfioConsumer(std::string device_name){
-  this->group_str = "/dev/vfio/" + get_iommu_group(device_name);
-  this->device_name = device_name;
+    this->group_str = "/dev/vfio/" + get_iommu_group(device_name);
+    this->device_name = device_name;
 }
 
 
 VfioConsumer::~VfioConsumer() {
-  printf("vfio consumer destructor called\n");
-  int ret;
-  ret = close(this->container);
-  if (ret < 0) {
-    warn("Cleanup: Cannot close vfio conatiner");
-  }
-  ret = close(this->group);
-  if (ret < 0) {
-    warn("Cleanup: Cannot close vfio group");
-  }
-  ret = close(this->device);
-  if (ret < 0) {
-    warn("Cleanup: Cannot close vfio device");
-  }
-  ret = munmap((void*)dma_map.vaddr, dma_map.size);
-  if (ret < 0) {
-    warn("Cleanup: Cannot unmap dma");
-  }
-  for (auto const& [idx, ptr] : this->mmio) {
-    ret = munmap(ptr, this->regions[idx].size);
+    printf("vfio consumer destructor called\n");
+    int ret;
+    ret = close(this->container);
     if (ret < 0) {
-      warn("Cleanup: Cannot unmap BAR regions %d", idx);
+        warn("Cleanup: Cannot close vfio conatiner");
     }
-  }
+    ret = close(this->group);
+    if (ret < 0) {
+        warn("Cleanup: Cannot close vfio group");
+    }
+    ret = close(this->device);
+    if (ret < 0) {
+        warn("Cleanup: Cannot close vfio device");
+    }
+    ret = munmap((void*)dma_map.vaddr, dma_map.size);
+    if (ret < 0) {
+        warn("Cleanup: Cannot unmap dma");
+    }
+    for (auto const& [idx, ptr] : this->mmio) {
+        ret = munmap(ptr, this->regions[idx].size);
+        if (ret < 0) {
+            warn("Cleanup: Cannot unmap BAR regions %d", idx);
+        }
+    }
 }
+
 
 int VfioConsumer::init() {
-  int ret, container, group, device;
-  uint32_t i;
-  struct vfio_group_status group_status =
-                                  { .argsz = sizeof(group_status) };
-  struct vfio_iommu_type1_info iommu_info = { .argsz = sizeof(iommu_info) };
-  struct vfio_iommu_type1_dma_map dma_map = { .argsz = sizeof(dma_map) };
-  struct vfio_device_info device_info = { .argsz = sizeof(device_info) };
+    int ret, container, group, device;
+    uint32_t i;
+    struct vfio_group_status group_status = { .argsz = sizeof(group_status) };
+    struct vfio_iommu_type1_info iommu_info = { .argsz = sizeof(iommu_info) };
+    struct vfio_iommu_type1_dma_map dma_map = { .argsz = sizeof(dma_map) };
+    struct vfio_device_info device_info = { .argsz = sizeof(device_info) };
 
-  /* Create a new container */
-  container = open("/dev/vfio/vfio", O_RDWR);
-  if (container < 0) {
-    die("Cannot open /dev/vfio/vfio");
-  }
-  this->container = container;
+    /* Create a new container */
+    container = open("/dev/vfio/vfio", O_RDWR);
+    if (container < 0) {
+        die("Cannot open /dev/vfio/vfio");
+    }
+    this->container = container;
 
-  if (ioctl(container, VFIO_GET_API_VERSION) != VFIO_API_VERSION) {
-    /* Unknown API version */
-    die("VFIO version mismatch");
-  }
+    if (ioctl(container, VFIO_GET_API_VERSION) != VFIO_API_VERSION) {
+        /* Unknown API version */
+        die("VFIO version mismatch");
+    }
 
-  if (!ioctl(container, VFIO_CHECK_EXTENSION, VFIO_TYPE1v2_IOMMU)) {
-    /* Doesn't support the IOMMU driver we want. */
-    die("VFIO extension unsupported");
-  }
+    if (!ioctl(container, VFIO_CHECK_EXTENSION, VFIO_TYPE1v2_IOMMU)) {
+        /* Doesn't support the IOMMU driver we want. */
+        die("VFIO extension unsupported");
+    }
 
-  /* Open the group */
-  group = open(group_str.c_str(), O_RDWR);
-  if (group < 0) {
-    die("Cannot open %s",group_str.c_str());
-  }
-  this->group = group;
+    /* Open the group */
+    group = open(group_str.c_str(), O_RDWR);
+    if (group < 0) {
+        die("Cannot open %s",group_str.c_str());
+    }
+    this->group = group;
 
-  /* Test the group is viable and available */
-  ret = ioctl(group, VFIO_GROUP_GET_STATUS, &group_status);
-  if (ret < 0) {
-    die("Cannot get vfio satus");
-  }
+    /* Test the group is viable and available */
+    ret = ioctl(group, VFIO_GROUP_GET_STATUS, &group_status);
+    if (ret < 0) {
+        die("Cannot get vfio satus");
+    }
 
-  if (!(group_status.flags & VFIO_GROUP_FLAGS_VIABLE)) {
-    /* Group is not viable (ie, not all devices bound for vfio) */
-    die("Some flag missing");
-  }
+    if (!(group_status.flags & VFIO_GROUP_FLAGS_VIABLE)) {
+        /* Group is not viable (ie, not all devices bound for vfio) */
+        die("Some flag missing");
+    }
 
-  /* Add the group to the container */
-  ret = ioctl(group, VFIO_GROUP_SET_CONTAINER, &container);
-  if (ret < 0) {
-    die("Cannot set vfio container");
-  }
+    /* Add the group to the container */
+    ret = ioctl(group, VFIO_GROUP_SET_CONTAINER, &container);
+    if (ret < 0) {
+        die("Cannot set vfio container");
+    }
 
-  /* Enable the IOMMU model we want */
-  ret = ioctl(container, VFIO_SET_IOMMU, VFIO_TYPE1_IOMMU);
-  if (ret < 0) {
-    die("Cannot set iommu type");
-  }
+    /* Enable the IOMMU model we want */
+    ret = ioctl(container, VFIO_SET_IOMMU, VFIO_TYPE1_IOMMU);
+    if (ret < 0) {
+        die("Cannot set iommu type");
+    }
 
-  /* Get addition IOMMU info */
-  ret = ioctl(container, VFIO_IOMMU_GET_INFO, &iommu_info);
-  if (ret < 0) {
-    die("Cannot get iommu info");
-  }
+    /* Get addition IOMMU info */
+    ret = ioctl(container, VFIO_IOMMU_GET_INFO, &iommu_info);
+    if (ret < 0) {
+        die("Cannot get iommu info");
+    }
 
-  /* Allocate some space and setup a DMA mapping */
-  dma_map.vaddr = (uint64_t)(mmap(0, 1024 * 1024, PROT_READ | PROT_WRITE,
-                       MAP_PRIVATE | MAP_ANONYMOUS, 0, 0));
-  if (dma_map.vaddr == (uint64_t) MAP_FAILED) {
-    die("Cannot allocate memory for DMA map");
-  }
-  dma_map.size = 1024 * 1024;
-  dma_map.iova = 0; /* 1MB starting at 0x0 from device view */
-  dma_map.flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE;
+    /* Allocate some space and setup a DMA mapping */
+    dma_map.vaddr = (uint64_t)(mmap(0, 1024 * 1024, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS, 0, 0));
+    if (dma_map.vaddr == (uint64_t) MAP_FAILED) {
+        die("Cannot allocate memory for DMA map");
+    }
+    dma_map.size = 1024 * 1024;
+    dma_map.iova = 0; /* 1MB starting at 0x0 from device view */
+    dma_map.flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE;
 
-  //ret = ioctl(container, VFIO_IOMMU_MAP_DMA, &dma_map);
-  //if (ret < 0) {
+    //ret = ioctl(container, VFIO_IOMMU_MAP_DMA, &dma_map);
+    //if (ret < 0) {
     //die("Cannot set dma map");
-  //}
-  this->dma_map = dma_map;
+    //}
+    this->dma_map = dma_map;
 
-  /* Get a file descriptor for the device */
-  device = ioctl(group, VFIO_GROUP_GET_DEVICE_FD, device_name.c_str());
-  if (device < 0) {
-    die("Cannot get/find device id in IOMMU group fd %d", group);
-  }
-  this->device = device;
+    /* Get a file descriptor for the device */
+    device = ioctl(group, VFIO_GROUP_GET_DEVICE_FD, device_name.c_str());
+    if (device < 0) {
+        die("Cannot get/find device id in IOMMU group fd %d", group);
+    }
+    this->device = device;
 
-  /* Test and setup the device */
-  ret = ioctl(device, VFIO_DEVICE_GET_INFO, &device_info);
-  if (ret < 0) {
-    die("Cannot get device info for device %d", device);
-  }
+    /* Test and setup the device */
+    ret = ioctl(device, VFIO_DEVICE_GET_INFO, &device_info);
+    if (ret < 0) {
+        die("Cannot get device info for device %d", device);
+    }
 
-  printf("\nDevice regions: %d\n\n", device_info.num_regions);
+    printf("\nDevice regions: %d\n\n", device_info.num_regions);
 
-  for (i = 0; i < device_info.num_regions; i++) {
-          struct vfio_region_info reg = { .argsz = sizeof(reg) };
+    for (i = 0; i < device_info.num_regions; i++) {
+        struct vfio_region_info reg = { .argsz = sizeof(reg) };
 
-          reg.index = i;
+        reg.index = i;
 
-          ioctl(device, VFIO_DEVICE_GET_REGION_INFO, &reg);
-          __builtin_dump_struct(&reg, &printf);
-          this->regions.push_back(reg);
+        ioctl(device, VFIO_DEVICE_GET_REGION_INFO, &reg);
+        __builtin_dump_struct(&reg, &printf);
+        this->regions.push_back(reg);
 
-          /* Setup mappings... read/write offsets, mmaps
-           * For PCI devices, config space is a region */
-  }
+        /* Setup mappings... read/write offsets, mmaps
+         * For PCI devices, config space is a region */
+    }
 
-  printf("\nDevice irsq: %d\n\n", device_info.num_irqs);
+    printf("\nDevice irsq: %d\n\n", device_info.num_irqs);
 
-  // Enable DMA
-  struct vfio_region_info* cs_info = &this->regions[VFIO_PCI_CONFIG_REGION_INDEX];
-  char buf[2];
-  pread(device, buf, 2, cs_info->offset + 4);
-  *(uint16_t*)(buf) |= 1 << 2;
-  pwrite(device, buf, 2, cs_info->offset + 4);
+    // Enable DMA
+    struct vfio_region_info* cs_info = &this->regions[VFIO_PCI_CONFIG_REGION_INDEX];
+    char buf[2];
+    pread(device, buf, 2, cs_info->offset + 4);
+    *(uint16_t*)(buf) |= 1 << 2;
+    pwrite(device, buf, 2, cs_info->offset + 4);
 
-  for (i = 0; i < device_info.num_irqs; i++) {
-          struct vfio_irq_info irq = { .argsz = sizeof(irq) };
+    for (i = 0; i < device_info.num_irqs; i++) {
+        struct vfio_irq_info irq = { .argsz = sizeof(irq) };
 
-          irq.index = i;
+        irq.index = i;
 
-          ioctl(device, VFIO_DEVICE_GET_IRQ_INFO, &irq);
-          __builtin_dump_struct(&irq, &printf);
-          this->interrupts.push_back(irq);
+        ioctl(device, VFIO_DEVICE_GET_IRQ_INFO, &irq);
+        __builtin_dump_struct(&irq, &printf);
+        this->interrupts.push_back(irq);
 
-          /* Setup IRQs... eventfds, VFIO_DEVICE_SET_IRQS */
-  }
+        /* Setup IRQs... eventfds, VFIO_DEVICE_SET_IRQS */
+    }
 
-  /* Gratuitous device reset and go... */
-  ioctl(device, VFIO_DEVICE_RESET);
+    /* Gratuitous device reset and go... */
+    ioctl(device, VFIO_DEVICE_RESET);
 
-  //Get Header size to determine if the device is PCI or PCIe
-  std::string config_path = "/sys/bus/pci/devices/" + this->device_name + "/config";
-  FILE *fd = fopen(config_path.c_str(), "rb");
-  if (fd == NULL)
-    die("Cannot open %s", config_path.c_str());
+    //Get Header size to determine if the device is PCI or PCIe
+    std::string config_path =
+        "/sys/bus/pci/devices/" + this->device_name + "/config";
+    FILE *fd = fopen(config_path.c_str(), "rb");
+    if (fd == NULL)
+        die("Cannot open %s", config_path.c_str());
 
-  
-  char* tmp[PCIE_HEADER_LENGTH];
-  size_t size = fread(tmp, sizeof(char), PCIE_HEADER_LENGTH, fd);
-  switch (size)
-  {
-  case 256:
-    printf("Device is PCI only\n");
-    this->is_pcie = false;
-    this->use_msix = false;
-    break;
-  case PCIE_HEADER_LENGTH:
-    printf("Device is PCIe\n");
-    this->is_pcie = true;
-    this->use_msix = true;
-    break;  
-  default:
-    die("only %zu bytes read", size);
-    break;
-  }
-  fclose(fd);
 
-  return 0;
+    char* tmp[PCIE_HEADER_LENGTH];
+    size_t size = fread(tmp, sizeof(char), PCIE_HEADER_LENGTH, fd);
+    switch (size)
+    {
+        case 256:
+            printf("Device is PCI only\n");
+            this->is_pcie = false;
+            this->use_msix = false;
+            break;
+        case PCIE_HEADER_LENGTH:
+            printf("Device is PCIe\n");
+            this->is_pcie = true;
+            this->use_msix = true;
+            break;  
+        default:
+            die("only %zu bytes read", size);
+            break;
+    }
+    fclose(fd);
+
+    return 0;
 }
+
 
 int VfioConsumer::init_mmio() {
-  // Only iterate bars 0-5. Bar >=6 seems not mappable. 
-  int num_regions = 5;
-  if(!this->is_pcie){
-    num_regions = 0;
-  }
-  for (int i = 0; i <= num_regions; i++) { 
-    auto region = this->regions[i];
-    if (region.size == 0) {
-      printf("Mapping region BAR %d skipped\n", region.index);
-      continue;
+    // Only iterate bars 0-5. Bar >=6 seems not mappable. 
+    int num_regions = 5;
+    if(!this->is_pcie){
+        num_regions = 0;
     }
-    void* mem = mmap(NULL, region.size, PROT_READ | PROT_WRITE, MAP_SHARED, this->device, region.offset);
-    if (mem == MAP_FAILED) {
-      die("failed to map mmio region BAR %d via vfio", region.index);
+    for (int i = 0; i <= num_regions; i++) { 
+        auto region = this->regions[i];
+        if (region.size == 0) {
+            printf("Mapping region BAR %d skipped\n", region.index);
+            continue;
+        }
+        void* mem = mmap(NULL, region.size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                this->device, region.offset);
+        if (mem == MAP_FAILED) {
+            die("failed to map mmio region BAR %d via vfio", region.index);
+        }
+        this->mmio[region.index] = mem;
+        printf("Vfio: Mapping region BAR %d offset 0x%llx size 0x%llx\n",
+                region.index, region.offset, region.size);
     }
-    this->mmio[region.index] = mem;
-    printf("Vfio: Mapping region BAR %d offset 0x%llx size 0x%llx\n", region.index, region.offset, region.size);
-  }
-  return 0;
+    return 0;
 }
 
-void vfio_set_irqs(const int irq_type, const size_t count, std::vector<int> *irqfds, int device_fd) {
-  int ret;
 
-  auto irq_set_buf_size = sizeof(struct vfio_irq_set) + sizeof(int) * count;
-  auto irq_set = (struct vfio_irq_set*) malloc(irq_set_buf_size);
-  irq_set->argsz = irq_set_buf_size;
-  irq_set->count = count;
-  irq_set->flags = VFIO_IRQ_SET_DATA_EVENTFD | VFIO_IRQ_SET_ACTION_TRIGGER;
-  irq_set->index = irq_type;
-  irq_set->start = 0;
+void vfio_set_irqs(const int irq_type, const size_t count,
+        std::vector<int> *irqfds, int device_fd)
+{
+    int ret;
 
-  for (uint64_t i = 0; i < count; i++) {
-    int fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-    if (fd < 0) {
-      if (errno == EMFILE) {
-        die("Cant create eventfd nr. %lu. Use `ulimit -n` to set a higher limit", i);
-      }
-      die("Failed to create eventfd");
+    auto irq_set_buf_size = sizeof(struct vfio_irq_set) + sizeof(int) * count;
+    auto irq_set = (struct vfio_irq_set*) malloc(irq_set_buf_size);
+    irq_set->argsz = irq_set_buf_size;
+    irq_set->count = count;
+    irq_set->flags = VFIO_IRQ_SET_DATA_EVENTFD | VFIO_IRQ_SET_ACTION_TRIGGER;
+    irq_set->index = irq_type;
+    irq_set->start = 0;
+
+    for (uint64_t i = 0; i < count; i++) {
+        int fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+        if (fd < 0) {
+            if (errno == EMFILE) {
+                die("Cant create eventfd nr. \
+                        %lu. Use `ulimit -n` to set a higher limit", i);
+            }
+            die("Failed to create eventfd");
+        }
+        irqfds->push_back(fd);
     }
-    irqfds->push_back(fd);
-  }
-  
-  memcpy((int*)&irq_set->data, irqfds->data(), sizeof(int) * count);
-  __builtin_dump_struct(irq_set, &printf);
-  printf("irqfds %d-%d (#%zu)\n", irqfds->front(), irqfds->back(), irqfds->size());
-  ret = ioctl(device_fd, VFIO_DEVICE_SET_IRQS, irq_set);
-  if (ret < 0) {
-    //TODO: IRQs don't work properly on the e1000 yet
-    printf("Cannot set eventfds for interrupts type %d for device %d\n", irq_type, device_fd);
-  }
+
+    memcpy((int*)&irq_set->data, irqfds->data(), sizeof(int) * count);
+    __builtin_dump_struct(irq_set, &printf);
+    printf("irqfds %d-%d (#%zu)\n",
+            irqfds->front(), irqfds->back(),irqfds->size());
+    ret = ioctl(device_fd, VFIO_DEVICE_SET_IRQS, irq_set);
+    if (ret < 0) {
+        //TODO: IRQs don't work properly on the e1000 yet
+        printf("Cannot set eventfds for interrupts type %d for device %d\n",
+                irq_type, device_fd);
+    }
 }
+
 
 void VfioConsumer::init_msix() {
-  if (!this->use_msix) {
-    printf("init for msix skipped because we run in intx mode\n");
-    return; 
-  }
+    if (!this->use_msix) {
+        printf("init for msix skipped because we run in intx mode\n");
+        return; 
+    }
 
-  uint32_t count = this->interrupts[VFIO_PCI_MSIX_IRQ_INDEX].count;
-  if (count <= 0) {
-    die("We expect devices to use MSIX IRQs/interrupts. This one doesnt right now");
-  }
+    uint32_t count = this->interrupts[VFIO_PCI_MSIX_IRQ_INDEX].count;
+    if (count <= 0) {
+        die("We expect devices to use MSIX IRQs/interrupts. \
+                This one doesnt right now");
+    }
 
-  vfio_set_irqs(VFIO_PCI_MSIX_IRQ_INDEX, count, &this->irqfds, this->device);
+    vfio_set_irqs(VFIO_PCI_MSIX_IRQ_INDEX, count, &this->irqfds, this->device);
 
-  printf("Eventfds registered for %d MSIX interrupts.\n", count);
+    printf("Eventfds registered for %d MSIX interrupts.\n", count);
 
 }
+
 
 void VfioConsumer::init_legacy_irqs() {
-  std::vector<int> irqfds;
-  // registering INTX and MSI fails with EINVAL. Experimentation shows, that only one of INTX, MSI or MSIX can be registered. 
-  // MSI and MSIX must indeed not be used simultaniousely by software (pci 4.0 section 6.1.4 MSI and MSI-X Operation).
-  // Simultaneous use of INTX and MSI(X) seems to be a shortcoming in libvfio-user right now. See https://github.com/nutanix/libvfio-user/issues/388 about insufficient irq impl and https://github.com/nutanix/libvfio-user/issues/387 about no way to trigger ERR or REQ irqs.
-  if (!this->use_msix) {
-    if (this->interrupts[VFIO_PCI_INTX_IRQ_INDEX].count != 1) {
-      die("This device does not support legacy INTx");
+    std::vector<int> irqfds;
+    // registering INTX and MSI fails with EINVAL. Experimentation shows, that
+    // only one of INTX, MSI or MSIX can be registered. MSI and MSIX must
+    // indeed not be used simultaniousely by software (pci 4.0 section 6.1.4
+    // MSI and MSI-X Operation). Simultaneous use of INTX and MSI(X) seems to
+    // be a shortcoming in libvfio-user right now. See
+    // https://github.com/nutanix/libvfio-user/issues/388 about insufficient
+    // irq impl and https://github.com/nutanix/libvfio-user/issues/387 about no
+    // way to trigger ERR or REQ irqs.
+    if (!this->use_msix) {
+        if (this->interrupts[VFIO_PCI_INTX_IRQ_INDEX].count != 1) {
+            die("This device does not support legacy INTx");
+        }
+        vfio_set_irqs(VFIO_PCI_INTX_IRQ_INDEX, 1, &irqfds, this->device);
+        this->irqfd_intx = irqfds.back();
+        irqfds.clear();
     }
-    vfio_set_irqs(VFIO_PCI_INTX_IRQ_INDEX, 1, &irqfds, this->device);
-    this->irqfd_intx = irqfds.back();
+    // vfio_set_irqs(VFIO_PCI_MSI_IRQ_INDEX, 1, &irqfds, this->device);
+    // this->irqfd_msi = irqfds.back();
+    // irqfds.clear();
+    vfio_set_irqs(VFIO_PCI_ERR_IRQ_INDEX, 1, &irqfds, this->device);
+    this->irqfd_err = irqfds.back();
     irqfds.clear();
-  }
-  //vfio_set_irqs(VFIO_PCI_MSI_IRQ_INDEX, 1, &irqfds, this->device);
-  //this->irqfd_msi = irqfds.back();
-  //irqfds.clear();
-  vfio_set_irqs(VFIO_PCI_ERR_IRQ_INDEX, 1, &irqfds, this->device);
-  this->irqfd_err = irqfds.back();
-  irqfds.clear();
-  vfio_set_irqs(VFIO_PCI_REQ_IRQ_INDEX, 1, &irqfds, this->device);
-  this->irqfd_req = irqfds.back();
+    vfio_set_irqs(VFIO_PCI_REQ_IRQ_INDEX, 1, &irqfds, this->device);
+    this->irqfd_req = irqfds.back();
 }
 
-void VfioConsumer::mask_irqs(uint32_t irq_type, uint32_t start, uint32_t count, bool mask) {
-  if (irq_type == VFIO_PCI_INTX_IRQ_INDEX && this->use_msix) {
-    printf("irq_state_cb for intx ignored because we run in msi-x mode\n");
-    return; 
-  }
 
-  uint32_t flags = VFIO_IRQ_SET_DATA_NONE;
-  if (mask) {
-    flags |= VFIO_IRQ_SET_ACTION_MASK;
-  } else {
-    flags |= VFIO_IRQ_SET_ACTION_UNMASK;
-  }
+void VfioConsumer::mask_irqs(uint32_t irq_type, uint32_t start,
+        uint32_t count, bool mask)
+{
+    if (irq_type == VFIO_PCI_INTX_IRQ_INDEX && this->use_msix) {
+        printf("irq_state_cb for intx ignored because we run in msi-x mode\n");
+        return; 
+    }
 
-  struct vfio_irq_set irq_set;
-  memset(&irq_set, 0, sizeof(irq_set)); // zero also .data
-  irq_set.argsz = sizeof(irq_set);
-  irq_set.flags = flags;
-  irq_set.index = irq_type;
-  irq_set.start = start;
-  irq_set.count = count;
-  //irq_set.data = { 0, 0 };
-  __builtin_dump_struct(&irq_set, &printf);
-  int ret = ioctl(this->device, VFIO_DEVICE_SET_IRQS, &irq_set);
-  if (ret < 0)
-    die("failed to mask irq");
+    uint32_t flags = VFIO_IRQ_SET_DATA_NONE;
+    if (mask) {
+        flags |= VFIO_IRQ_SET_ACTION_MASK;
+    } else {
+        flags |= VFIO_IRQ_SET_ACTION_UNMASK;
+    }
+
+    struct vfio_irq_set irq_set;
+    memset(&irq_set, 0, sizeof(irq_set)); // zero also .data
+    irq_set.argsz = sizeof(irq_set);
+    irq_set.flags = flags;
+    irq_set.index = irq_type;
+    irq_set.start = start;
+    irq_set.count = count;
+    //irq_set.data = { 0, 0 };
+    __builtin_dump_struct(&irq_set, &printf);
+    int ret = ioctl(this->device, VFIO_DEVICE_SET_IRQS, &irq_set);
+    if (ret < 0)
+        die("failed to mask irq");
 }
+
 
 void VfioConsumer::reset_device() {
-  // TODO check if device supports reset VFIO_DEVICE_FLAGS_RESET
-  int ret = ioctl(this->device, VFIO_DEVICE_RESET, NULL);
-  
-  if (ret < 0)
-    printf("failed to reset device\n");
+    // TODO check if device supports reset VFIO_DEVICE_FLAGS_RESET
+    int ret = ioctl(this->device, VFIO_DEVICE_RESET, NULL);
+
+    if (ret < 0)
+        printf("failed to reset device\n");
     //TODO
 }
 
+
 void VfioConsumer::map_dma(vfio_iommu_type1_dma_map *dma_map) {
-  int ret = ioctl(this->container, VFIO_IOMMU_MAP_DMA, dma_map);
-  if (ret < 0){
-    	printf("\033[31mvifo failed to map dma, %d: %s\033[0m\n",errno, strerror(errno));
-	printf("\033[31m");
-	__builtin_dump_struct(dma_map, &printf);
-	printf("\033[0m");
-	return;
-	die("vfio failed to map dma, %d",errno);
-	
-  }
+    int ret = ioctl(this->container, VFIO_IOMMU_MAP_DMA, dma_map);
+    if (ret < 0){
+        printf("\033[31mvifo failed to map dma, %d: %s\033[0m\n",
+                errno, strerror(errno));
+        printf("\033[31m");
+        __builtin_dump_struct(dma_map, &printf);
+        printf("\033[0m");
+        return;
+        die("vfio failed to map dma, %d",errno);
+
+    }
 }
 
-void VfioConsumer::unmap_dma(vfio_iommu_type1_dma_unmap *dma_unmap) {
-  int ret = ioctl(this->container, VFIO_IOMMU_UNMAP_DMA, dma_unmap);
-  // TODO check dma_unmap size as well
-  if (ret < 0)
-    die("vfio failed to unmap dma");
+
+void VfioConsumer::unmap_dma(vfio_iommu_type1_dma_unmap *dma_unmap)
+{
+    int ret = ioctl(this->container, VFIO_IOMMU_UNMAP_DMA, dma_unmap);
+    // TODO check dma_unmap size as well
+    if (ret < 0)
+        die("vfio failed to unmap dma");
 }

--- a/src/vfio-consumer.hpp
+++ b/src/vfio-consumer.hpp
@@ -1,48 +1,52 @@
 #pragma once
-#include<vector>
+
+#include <vector>
 #include <map>
 #include <linux/vfio.h>
 #include <string>
+
 extern "C" {
-  #include "libvfio-user.h"
+#include "libvfio-user.h"
 }
+
 
 /**
  * Endpoint towards kernel
  */
 class VfioConsumer {
-  public:
-    std::vector<struct vfio_region_info> regions;
-    std::vector<struct vfio_irq_info> interrupts;
-    std::vector<int> irqfds; // eventfds for MSIX interrupts
-    int irqfd_intx; // more legacy interrupts
-    int irqfd_msi;
-    int irqfd_err;
-    int irqfd_req;
-    std::map<int, void*> mmio;
-    struct vfio_iommu_type1_dma_map dma_map;
-    bool use_msix = true;
-    bool is_pcie = true;
+    public:
+        std::vector<struct vfio_region_info> regions;
+        std::vector<struct vfio_irq_info> interrupts;
+        std::vector<int> irqfds; // eventfds for MSIX interrupts
+        int irqfd_intx; // more legacy interrupts
+        int irqfd_msi;
+        int irqfd_err;
+        int irqfd_req;
+        std::map<int, void*> mmio;
+        struct vfio_iommu_type1_dma_map dma_map;
+        bool use_msix = true;
+        bool is_pcie = true;
 
-    std::string group_str;
-    std::string device_name;
+        std::string group_str;
+        std::string device_name;
 
-    // vfio fds
-    int container;
-    int group;
-    int device;
+        // vfio fds
+        int container;
+        int group;
+        int device;
 
-    ~VfioConsumer();
-    VfioConsumer(std::string group_str, std::string device_name);
-    VfioConsumer(std::string device_name);
-    int init();
-    int init_mmio();
-    void init_msix();
-    void init_legacy_irqs();
-    void reset_device();
-    void map_dma(vfio_iommu_type1_dma_map *dma_map);
-    void unmap_dma(vfio_iommu_type1_dma_unmap *dma_unmap);
-    void mask_irqs(uint32_t irq_type, uint32_t start, uint32_t count, bool mask);
+        VfioConsumer(std::string group_str, std::string device_name);
+        VfioConsumer(std::string device_name);
+        ~VfioConsumer();
+
+        int init();
+        int init_mmio();
+        void init_msix();
+        void init_legacy_irqs();
+        void reset_device();
+        void map_dma(vfio_iommu_type1_dma_map *dma_map);
+        void unmap_dma(vfio_iommu_type1_dma_unmap *dma_unmap);
+        void mask_irqs(uint32_t irq_type, uint32_t start, uint32_t count, bool mask);
 };
 
 #define VFIOC_SECRET 1337

--- a/src/vfio-server.hpp
+++ b/src/vfio-server.hpp
@@ -22,460 +22,532 @@
 #include <dirent.h>
 #include <set>
 #include <signal.h>
+#include <thread>
+#include <sys/epoll.h>
+
 #include "src/vfio-consumer.hpp"
 #include "src/util.hpp"
 #include "src/caps.hpp"
-#include <thread>
-#include <sys/epoll.h>
+
 extern "C" {
-  #include "libvfio-user.h"
+#include "libvfio-user.h"
 }
 
-#include "util.hpp"
 
 class VfioUserServer;
 
+
 struct interrupt_callback{
-  int fd;
-  void (*callback)(int, VfioUserServer*);
-  VfioUserServer* vfu;
-  int irq_subindex;
+    int fd;
+    void (*callback)(int, VfioUserServer*);
+    VfioUserServer* vfu;
+    int irq_subindex;
 };
 
 
 class VfioUserServer {
-  public:
-    vfu_ctx_t *vfu_ctx;
-    std::string sock;
-    std::optional<size_t> run_ctx_pollfd_idx; // index of pollfd in pollfds
-    size_t irq_intx_pollfd_idx; // only one
-    size_t irq_msi_pollfd_idx; // only one
-    size_t irq_msix_pollfd_idx; // multiple
-    size_t irq_msix_pollfd_count;
-    size_t irq_err_pollfd_idx; // only one
-    size_t irq_req_pollfd_idx; // only one
-    std::vector<struct pollfd> pollfds;
-    VfioConsumer *callback_context;
-    std::set<void*> mapped;
-    std::map<void*, dma_sg_t*> sgs;
+    public:
+        vfu_ctx_t *vfu_ctx;
+        std::string sock;
+        std::optional<size_t> run_ctx_pollfd_idx; // index of pollfd in pollfds
+        size_t irq_intx_pollfd_idx; // only one
+        size_t irq_msi_pollfd_idx; // only one
+        size_t irq_msix_pollfd_idx; // multiple
+        size_t irq_msix_pollfd_count;
+        size_t irq_err_pollfd_idx; // only one
+        size_t irq_req_pollfd_idx; // only one
+        std::vector<struct pollfd> pollfds;
+        VfioConsumer *callback_context;
+        std::set<void*> mapped;
+        std::map<void*, dma_sg_t*> sgs;
 
-    int efd;
+        int efd;
 
-    /// MSIX irqs + 1 intx + 1 msi + 1 err + 1 req
-    static const size_t IC_MAX = PCI_MSIX_MAX + 4;
-    interrupt_callback ic[IC_MAX];
-    size_t ic_used;
+        /// MSIX irqs + 1 intx + 1 msi + 1 err + 1 req
+        static const size_t IC_MAX = PCI_MSIX_MAX + 4;
+        interrupt_callback ic[IC_MAX];
+        size_t ic_used;
 
-
-    VfioUserServer(std::string sock, int efd) {
-      this->sock = sock;
-      this->efd = efd;
-      ic_used = 0;
-      int ret  = std::remove(this->sock.c_str());
-      if (ret != 0) {
-        if (errno == ENOENT) {
-          // printf("Did not clean up old sockets because none are there.\n");
-        } else {
-          die("Failed to clean up existing socket %s\n", this->sock.c_str());
-        }
-      }
-    }
-
-    ~VfioUserServer() {
-      int ret;
-      vfu_destroy_ctx(vfu_ctx); // this should also close this->run_ctx_pollfd_idx.value()
-      
-      // close remaining fds
-      for (auto fd : this->pollfds) {
-        if (fd.fd == this->get_run_ctx_poll_fd()->fd) {
-          continue;
-        }
-        ret = close(fd.fd);
-        if (ret < 0)
-          warn("Cleanup: Cannot close fd %d", fd.fd);
-      }
-
-      // if vfu_destroy_ctx is successfull, this might not be needed
-      ret = unlink(sock.c_str());
-      if (ret < 0) {
-        warn("Cleanup: Could not delete %s", sock.c_str());
-      }
-    }
-
-    int add_regions(std::vector<struct vfio_region_info> regions, int device_fd) {
-      int ret;
-
-      if (regions.size() > VFU_PCI_DEV_VGA_REGION_IDX - VFU_PCI_DEV_BAR0_REGION_IDX + 1)
-        printf("Warning: got %u mappable regions, but we expect normal PCI to have %d at most\n", (uint)regions.size(), VFU_PCI_DEV_VGA_REGION_IDX - VFU_PCI_DEV_BAR0_REGION_IDX + 1);
-      // Note, that we only attempt to map bar 0-5
-      for (int i = VFU_PCI_DEV_BAR0_REGION_IDX; i <= VFU_PCI_DEV_BAR5_REGION_IDX; i++) {
-        ret = this->add_region(&regions[i], device_fd);
-        if (ret < 0) {
-            die("failed to add dma region to vfio-user");
-        }
-      }
-
-      return 0;
-    }
-
-    int add_irqs(std::vector<struct vfio_irq_info> const irqs) {
-      int ret;
-      if (irqs.size() > VFU_DEV_REQ_IRQ - VFU_DEV_INTX_IRQ + 1)
-        printf("Warning: got %u irq types, but we only know %d at most\n", (uint)irqs.size(), VFU_DEV_REQ_IRQ - VFU_DEV_INTX_IRQ + 1);
-      for (int i = VFU_DEV_INTX_IRQ; i <= VFU_DEV_REQ_IRQ; i++) {
-        // TODO check ioeventfd compatibility
-        ret = vfu_setup_device_nr_irqs(this->vfu_ctx, (enum vfu_dev_irq_type)irqs[i].index, irqs[i].count);
-        if (ret < 0) {
-          die("Cannot set up vfio-user irq (type %d, num %d)", irqs[i].index, irqs[i].count);
+        VfioUserServer(std::string sock, int efd)
+        {
+            this->sock = sock;
+            this->efd = efd;
+            ic_used = 0;
+            int ret  = std::remove(this->sock.c_str());
+            if (ret != 0) {
+                if (errno == ENOENT) {
+                    // printf("Did not clean up old sockets because \
+                    // none are there.\n");
+                } else {
+                    die("Failed to clean up existing socket %s\n",
+                            this->sock.c_str());
+                }
+            }
         }
 
-        int fd = eventfd(0, 0); // TODO close
-        if (fd < 0) {
-          die("Cannot create eventfd for irq.");
+        ~VfioUserServer() {
+            int ret;
+            vfu_destroy_ctx(vfu_ctx); // this should also close
+                                      // this->run_ctx_pollfd_idx.value()
+
+            // close remaining fds
+            for (auto fd : this->pollfds) {
+                if (fd.fd == this->get_run_ctx_poll_fd()->fd) {
+                    continue;
+                }
+                ret = close(fd.fd);
+                if (ret < 0)
+                    warn("Cleanup: Cannot close fd %d", fd.fd);
+            }
+
+            // if vfu_destroy_ctx is successfull, this might not be needed
+            ret = unlink(sock.c_str());
+            if (ret < 0) {
+                warn("Cleanup: Could not delete %s", sock.c_str());
+            }
         }
-        //ret = vfu_create_ioeventfd(this->vfu_ctx, 
-        printf("Interrupt (type %d, num %d) set up.\n", irqs[i].index, irqs[i].count);
-      }
 
-      return 0;
-    }
+        int add_regions(std::vector<struct vfio_region_info> regions,
+                int device_fd)
+        {
+            int ret;
 
-    static void msix_callback(int fd, VfioUserServer* vfu){
+            if (regions.size() > VFU_PCI_DEV_VGA_REGION_IDX -
+                    VFU_PCI_DEV_BAR0_REGION_IDX + 1)
+                printf("Warning: got %u mappable regions, \
+                        but we expect normal PCI to have %d at most\n",
+                        (uint)regions.size(),VFU_PCI_DEV_VGA_REGION_IDX
+                        - VFU_PCI_DEV_BAR0_REGION_IDX + 1);
+            // Note, that we only attempt to map bar 0-5
+            for (int i = VFU_PCI_DEV_BAR0_REGION_IDX;
+                    i <= VFU_PCI_DEV_BAR5_REGION_IDX; i++) {
+                ret = this->add_region(&regions[i], device_fd);
+                if (ret < 0) {
+                    die("failed to add dma region to vfio-user");
+                }
+            }
 
-      //size_t irq_subindex = i - vfu.irq_msix_pollfd_idx;
-      int ret = vfu_irq_trigger(vfu->vfu_ctx, fd);
-      printf("Triggered interrupt. ret = %d, errno: %d\n", ret,errno);
-      if (ret < 0) {
-        die("Cannot trigger MSIX interrupt %d", fd);
-      }
+            return 0;
+        }
 
+        int add_irqs(std::vector<struct vfio_irq_info> const irqs)
+        {
+            int ret;
+            if (irqs.size() > VFU_DEV_REQ_IRQ - VFU_DEV_INTX_IRQ + 1)
+                printf("Warning: got %u irq types, \
+                        but we only know %d at most\n", (uint)irqs.size(),
+                        VFU_DEV_REQ_IRQ - VFU_DEV_INTX_IRQ + 1);
+            for (int i = VFU_DEV_INTX_IRQ; i <= VFU_DEV_REQ_IRQ; i++) {
+                // TODO check ioeventfd compatibility
+                ret = vfu_setup_device_nr_irqs(this->vfu_ctx,
+                        (enum vfu_dev_irq_type) irqs[i].index, irqs[i].count);
+                if (ret < 0) {
+                    die("Cannot set up vfio-user irq (type %d, num %d)",
+                            irqs[i].index, irqs[i].count);
+                }
 
-    }
-    static void msi_callback(int fd, VfioUserServer* vfu){
-      (void)vfu;
-      (void)fd;
-      printf("msi interrupt! unimplemented\n");
-    }
+                int fd = eventfd(0, 0); // TODO close
+                if (fd < 0) {
+                    die("Cannot create eventfd for irq.");
+                }
+                //ret = vfu_create_ioeventfd(this->vfu_ctx, 
+                printf("Interrupt (type %d, num %d) set up.\n",
+                        irqs[i].index, irqs[i].count);
+            }
 
-    static void intx_callback(int fd, VfioUserServer* vfu){
-      (void)vfu;
-      (void)fd;
-      printf("intx interrupt! unimplemented\n");
-    }
+            return 0;
+        }
 
-    static void err_callback(int fd, VfioUserServer* vfu){
-      (void)vfu;
-      (void)fd;
-      printf("err interrupt! unimplemented\n");
-    }
-
-    static void req_callback(int fd, VfioUserServer* vfu){
-      (void)vfu;
-      (void)fd;
-      printf("req interrupt! unimplemented\n");
-    }
-
-
-
-
-    void add_msix_pollfds(std::vector<int> const eventfds) {
-
-      
-      this->irq_msix_pollfd_idx = this->pollfds.size();
-      this->irq_msix_pollfd_count = eventfds.size();
-      
-      for(size_t i = 0; i < eventfds.size(); i++){
-        ic[ic_used].fd = eventfds[i];
-        ic[ic_used].callback = msix_callback;
-        ic[ic_used].vfu = this;
-        struct epoll_event e;
-        e.events = EPOLLIN;
-        e.data.ptr = &ic[ic_used++];
-        
-        epoll_ctl(efd,EPOLL_CTL_ADD, eventfds[i], &e);
-
-      }
-      if (!eventfds.empty())
-        printf("registered fds %d-%d to poll for msix interrupts\n", 
-            eventfds.front(), eventfds.back());
-      if (ic_used >= IC_MAX)
-        die("Tried to allocate more interrupt callbacks than expected");
-    }
-
-    void add_legacy_irq_pollfds(const int intx, const int msi, const int err, const int req) {
-      struct epoll_event e;
-
-      // intx may be 0 if unsupported by msix devices
-      if (intx != 0) {
-        ic[ic_used].fd = intx;
-        ic[ic_used].callback = intx_callback;
-        ic[ic_used].vfu = this;
-        
-        e.events = EPOLLIN;
-        e.data.ptr = &ic[ic_used++];
-        
-        epoll_ctl(efd,EPOLL_CTL_ADD, intx, &e);
-      }
-
-      // msi may be 0 if unsupported by msix devices
-      if (msi != 0) {
-        ic[ic_used].fd = msi;
-        ic[ic_used].callback = msi_callback;
-        ic[ic_used].vfu = this;
-        
-        e.events = EPOLLIN;
-        e.data.ptr = &ic[ic_used++];       
-
-        epoll_ctl(efd,EPOLL_CTL_ADD, msi, &e); 
-      }
-
-      ic[ic_used].fd = err;
-      ic[ic_used].callback = err_callback;
-      ic[ic_used].vfu = this;
-      
-      e.events = EPOLLIN;
-      e.data.ptr = &ic[ic_used++];       
-
-      epoll_ctl(efd,EPOLL_CTL_ADD, err, &e); 
-
-      ic[ic_used].fd = req;
-      ic[ic_used].callback = req_callback;
-      ic[ic_used].vfu = this;
-      
-      e.events = EPOLLIN;
-      e.data.ptr = &ic[ic_used++];       
-
-      epoll_ctl(efd,EPOLL_CTL_ADD, req, &e); 
-
-      if (ic_used >= IC_MAX)
-        die("Tried to allocate more interrupt callbacks than expected");
-
-      printf("register interrupt fds: intx %d, msi %d, err %d, req %d\n", intx, msi, err, req);
-    }
-
-    void reset_run_ctx_poll_fd() {
-      auto pfd = (struct pollfd) {
-          .fd = vfu_get_poll_fd(vfu_ctx),
-          .events = POLLIN
-          };
-      if (this->run_ctx_pollfd_idx.has_value()) {
-        close(this->pollfds[this->run_ctx_pollfd_idx.value()].fd);
-        this->pollfds[this->run_ctx_pollfd_idx.value()] = pfd;
-      } else {
-        this->run_ctx_pollfd_idx = this->pollfds.size();
-        this->pollfds.push_back(pfd);
-      }
-    }
-
-    struct pollfd* get_run_ctx_poll_fd() {
-        return &this->pollfds[this->run_ctx_pollfd_idx.value()];
-    }
-
-    void setup_callbacks(VfioConsumer *callback_context) {
-      int ret;
-      this->callback_context = callback_context;
-      // I think quiescing only applies when using vfu_add_to_sgl and vfu_sgl_read (see libvfio-user/docs/memory-mapping.md
-      //vfu_setup_device_quiesce_cb(this->vfu_ctx, VfioUserServer::quiesce_cb);
-      ret = vfu_setup_device_reset_cb(this->vfu_ctx, VfioUserServer::reset_device_cb);
-      if (ret)
-        die("setting up reset callback for libvfio-user failed %d", ret);
-      vfu_setup_device_dma(this->vfu_ctx, VfioUserServer::dma_register_cb, VfioUserServer::dma_unregister_cb);
-      ret = vfu_setup_irq_state_callback(this->vfu_ctx, VFU_DEV_INTX_IRQ, VfioUserServer::intx_state_cb);
-      if (ret)
-        die("setting up intx state callback for libvfio-user failed");
-      ret = vfu_setup_irq_state_callback(this->vfu_ctx, VFU_DEV_MSIX_IRQ, VfioUserServer::msix_state_cb);
-      if (ret)
-        die("setting up msix state callback for libvfio-user failed");
-      // register unimplemented callback for all unused interrupt types
-      for (int type = 0; type < VFU_DEV_NUM_IRQS; type++) {
-        if (type == VFU_DEV_INTX_IRQ || type == VFU_DEV_MSIX_IRQ)
-          continue;
-        ret = vfu_setup_irq_state_callback(this->vfu_ctx, (enum vfu_dev_irq_type) type, VfioUserServer::irq_state_unimplemented_cb);
-        if (ret)
-          die("setting up irq type %d callback for libvfio-user failed", type);
-      }
-    }
-
-  private:
-    static int reset_device_cb(vfu_ctx_t *vfu_ctx, [[maybe_unused]] vfu_reset_type_t type) {
-      VfioUserServer *vfu = (VfioUserServer*)vfu_get_private(vfu_ctx);
-      printf("resetting device\n"); // this happens at VM boot
-      vfu->callback_context->reset_device();
-      return 0;
-    }
-
-    static int quiesce_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx) {
-      // See vfu_setup_device_quiesce_cb().
-      //VfioUserServer *vfu = (VfioUserServer*)vfu_get_private(vfu_ctx);
-      //vfu_quiesce_done(vfu.vfu_ctx, 0);
-      //die("quiesce_cb unimplemented");
-      printf("quiescing device. Not sure when this ends.\n");
-      return 0;
-    }
-
-    static void dma_register_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx, [[maybe_unused]] vfu_dma_info_t *info) {
-      
-      printf("register dma cb\n");
-      
-      //if ( //info->iova.iov_base == NULL ||
-      //    info->iova.iov_base == (void*)0xc0000 || // TODO remove these checks as well
-      //    info->iova.iov_base == (void*)0xe0000 )
-      //  return;
-
-      //__builtin_dump_struct(info, &printf);
-      VfioUserServer *vfu = (VfioUserServer*)vfu_get_private(vfu_ctx);
-      printf("{\n");
-      for(void* const& p: vfu->mapped){
-        printf("%p\n",p);
-      }
-      printf("}\n");
-      uint32_t flags = 0;
-      if (PROT_READ & info->prot)
-        flags |= VFIO_DMA_MAP_FLAG_READ;
-      if (PROT_WRITE & info->prot)
-        flags |= VFIO_DMA_MAP_FLAG_WRITE;
-      __builtin_dump_struct(info, &printf);
-  
-      if (!info->vaddr){
-        //vfu_sgl_get failes if vaddr is NULL
-        printf("Region not mappable\n");
-        return;
-      }
-
-      //Map the region into the vmux Address Space
-      struct iovec* mapping = (struct iovec*)calloc(1,sizeof(struct iovec));
-      dma_sg_t *sgl = (dma_sg_t*)calloc(1, dma_sg_size());
-      int ret = vfu_addr_to_sgl(vfu_ctx,info->iova.iov_base,info->iova.iov_len,sgl,1,flags);
-      if(ret < 0){
-        die("Failed to get sgl for DMA\n");
-      }
-  
-      if(vfu_sgl_get(vfu_ctx ,sgl,mapping,1,0)){
-        die("Failed to populate iovec array");
-      }
-
-      
+        static void msix_callback(int fd, VfioUserServer* vfu)
+        {
+            //size_t irq_subindex = i - vfu.irq_msix_pollfd_idx;
+            int ret = vfu_irq_trigger(vfu->vfu_ctx, fd);
+            printf("Triggered interrupt. ret = %d, errno: %d\n", ret,errno);
+            if (ret < 0) {
+                die("Cannot trigger MSIX interrupt %d", fd);
+            }
 
 
-      printf("Add Address to mapped addresses\n");
-      vfu->sgs[info->vaddr] = sgl; 
-      vfu->mapped.insert(info->vaddr);
-      __builtin_dump_struct(info, &printf);
-      __builtin_dump_struct(mapping, &printf);
-      
-      
-      vfio_iommu_type1_dma_map dma_map = {
-        .argsz = sizeof(vfio_iommu_type1_dma_map),
-        .flags = flags,
-        .vaddr = (uint64_t)(info->vaddr),
-        .iova = (uint64_t)(info->iova.iov_base),
-        .size =  info->iova.iov_len,
-      };
-      __builtin_dump_struct(&dma_map, &printf);
-      vfu->callback_context->map_dma(&dma_map);
-    }
+        }
 
-    static void dma_unregister_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx, [[maybe_unused]] vfu_dma_info_t *info) {
-      printf("dma_unregister_cb\n");
-      //return;
+        static void msi_callback(int fd, VfioUserServer* vfu)
+        {
+            (void)vfu;
+            (void)fd;
+            printf("msi interrupt! unimplemented\n");
+        }
 
-      //if (// info->iova.iov_base == NULL ||
-      //    info->iova.iov_base == (void*)0xc0000 ||
-      //    info->iova.iov_base == (void*)0xe0000 )
-      //  return;
-      __builtin_dump_struct(info, &printf);
+        static void intx_callback(int fd, VfioUserServer* vfu)
+        {
+            (void)vfu;
+            (void)fd;
+            printf("intx interrupt! unimplemented\n");
+        }
 
-      VfioUserServer *vfu = (VfioUserServer*)vfu_get_private(vfu_ctx);
-      printf("{\n");
-      for(void* const& p: vfu->mapped){
-        printf("%p\n",p);
-      }
-      printf("}\n");
+        static void err_callback(int fd, VfioUserServer* vfu)
+        {
+            (void)vfu;
+            (void)fd;
+            printf("err interrupt! unimplemented\n");
+        }
+
+        static void req_callback(int fd, VfioUserServer* vfu)
+        {
+            (void)vfu;
+            (void)fd;
+            printf("req interrupt! unimplemented\n");
+        }
 
 
-      //info->mapping indicates if mapped
-      if(!info->mapping.iov_base){
-        printf("Region not mapped, nothing to do\n");
-        return;
-      }
 
 
-      if(!vfu->mapped.count(info->iova.iov_base)){
-        printf("Region seems not to be mapped\n");
-        //return;
-      }
-      if(vfu->sgs.count(info->vaddr)==1){
-        printf("dealloc sgl\n");
-      }
-      if(vfu->sgs.count(info->vaddr)>1){
-        printf("Why?\n");
-        //return;
-      }
+        void add_msix_pollfds(std::vector<int> const eventfds)
+        {
+            this->irq_msix_pollfd_idx = this->pollfds.size();
+            this->irq_msix_pollfd_count = eventfds.size();
 
+            for(size_t i = 0; i < eventfds.size(); i++){
+                ic[ic_used].fd = eventfds[i];
+                ic[ic_used].callback = msix_callback;
+                ic[ic_used].vfu = this;
+                struct epoll_event e;
+                e.events = EPOLLIN;
+                e.data.ptr = &ic[ic_used++];
 
-      vfio_iommu_type1_dma_unmap dma_unmap = {
-        .argsz = sizeof(vfio_iommu_type1_dma_unmap),
-        .flags = 0,
-        .iova = (uint64_t)(info->iova.iov_base),
-        .size = info->iova.iov_len,
-      };
-      vfu->callback_context->unmap_dma(&dma_unmap);
-    }
+                epoll_ctl(efd,EPOLL_CTL_ADD, eventfds[i], &e);
 
-    static void intx_state_cb(vfu_ctx_t *vfu_ctx, uint32_t start, uint32_t count, bool mask) {
-      VfioUserServer *vfu = (VfioUserServer*)vfu_get_private(vfu_ctx);
-      vfu->callback_context->mask_irqs(VFIO_PCI_INTX_IRQ_INDEX, start, count, mask);
-    }
+            }
+            if (!eventfds.empty())
+                printf("registered fds %d-%d to poll for msix interrupts\n", 
+                        eventfds.front(), eventfds.back());
+            if (ic_used >= IC_MAX)
+                die("Tried to allocate more interrupt \
+                        callbacks than expected");
+        }
 
-    static void msix_state_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx, [[maybe_unused]] uint32_t start, [[maybe_unused]] uint32_t count, [[maybe_unused]] bool mask) {
-      // masking of MSIx interrupts is unimplemented in linux/vfio (see vfio_pci_intrs.c:666)
-      printf("ignoring msix state cb (mask %u)\n", mask);
-      // TODO track maskedness of interrupts and make vmux apply the mask
-    }
+        void add_legacy_irq_pollfds(const int intx, const int msi,
+                const int err, const int req)
+        {
+            struct epoll_event e;
 
-    static void irq_state_unimplemented_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx, [[maybe_unused]] uint32_t start, [[maybe_unused]] uint32_t count, [[maybe_unused]] bool mask) {
-      die("irq_state_unimplemented_cb unimplemented");
-    }
+            // intx may be 0 if unsupported by msix devices
+            if (intx != 0) {
+                ic[ic_used].fd = intx;
+                ic[ic_used].callback = intx_callback;
+                ic[ic_used].vfu = this;
 
-    static ssize_t
-    unexpected_access_callback([[maybe_unused]] vfu_ctx_t *vfu_ctx, [[maybe_unused]] char * const buf, [[maybe_unused]] size_t count, [[maybe_unused]] __loff_t offset,
-                [[maybe_unused]] const bool is_write)
-    {
-      printf("Unexpectedly, a vfio register/DMA access callback was triggered (at 0x%lx, is write %d.\n", offset, is_write);
-      return 0;
-    }
+                e.events = EPOLLIN;
+                e.data.ptr = &ic[ic_used++];
 
-    int add_region(struct vfio_region_info *region, int device_fd) {
-      int ret;
+                epoll_ctl(efd,EPOLL_CTL_ADD, intx, &e);
+            }
 
-      if (region->size == 0) {
-        printf("Bar region %d skipped.\n", region->index);
-        return 0;
-      }
+            // msi may be 0 if unsupported by msix devices
+            if (msi != 0) {
+                ic[ic_used].fd = msi;
+                ic[ic_used].callback = msi_callback;
+                ic[ic_used].vfu = this;
 
-      // set up dma VM<->vmux
-      struct iovec bar_mmap_areas[] = {
-          //{ .iov_base  = (void*)region->offset, .iov_len = region->size}, // no cb, just shmem
-          { .iov_base  = (void*)0, .iov_len = region->size}, // no cb, just shmem
-      };
-      ret = vfu_setup_region(this->vfu_ctx, region->index,
-                             region->size, &(this->unexpected_access_callback),
-                             VFU_REGION_FLAG_RW | VFU_REGION_FLAG_MEM, bar_mmap_areas, 
-                             1, // nr. items in bar_mmap_areas
-                             device_fd, region->offset);
-      if (ret < 0) {
-          die("failed to setup BAR region %d", region->index);
-      }
+                e.events = EPOLLIN;
+                e.data.ptr = &ic[ic_used++];       
 
-      // init some flags that are also set with qemu passthrough
-      vfu_pci_config_space_t *config_space = vfu_pci_get_config_space(this->vfu_ctx);
-      vfu_bar_t *bar_config = &(config_space->hdr.bars[region->index]);
-      // see pci spec sec 7.5.1.2.1 for meaning of bits:
-      bar_config->mem.prefetchable = 1; // prefetchable
-      bar_config->mem.locatable = 0b10; // 64 bit
+                epoll_ctl(efd,EPOLL_CTL_ADD, msi, &e); 
+            }
 
-      printf("Vfio-user: Bar region %d (offset 0x%x, size 0x%x) set up.\n", region->index, (uint)region->offset, (uint)region->size);
+            ic[ic_used].fd = err;
+            ic[ic_used].callback = err_callback;
+            ic[ic_used].vfu = this;
 
-      return 0;
-    }
+            e.events = EPOLLIN;
+            e.data.ptr = &ic[ic_used++];       
+
+            epoll_ctl(efd,EPOLL_CTL_ADD, err, &e); 
+
+            ic[ic_used].fd = req;
+            ic[ic_used].callback = req_callback;
+            ic[ic_used].vfu = this;
+
+            e.events = EPOLLIN;
+            e.data.ptr = &ic[ic_used++];       
+
+            epoll_ctl(efd,EPOLL_CTL_ADD, req, &e); 
+
+            if (ic_used >= IC_MAX)
+                die("Tried to allocate more interrupt \
+                        callbacks than expected");
+
+            printf("register interrupt fds: intx %d, msi %d, err %d, req %d\n",
+                    intx, msi, err, req);
+        }
+
+        void reset_run_ctx_poll_fd()
+        {
+            auto pfd = (struct pollfd) {
+                .fd = vfu_get_poll_fd(vfu_ctx),
+                    .events = POLLIN
+            };
+            if (this->run_ctx_pollfd_idx.has_value()) {
+                close(this->pollfds[this->run_ctx_pollfd_idx.value()].fd);
+                this->pollfds[this->run_ctx_pollfd_idx.value()] = pfd;
+            } else {
+                this->run_ctx_pollfd_idx = this->pollfds.size();
+                this->pollfds.push_back(pfd);
+            }
+        }
+
+        struct pollfd* get_run_ctx_poll_fd()
+        {
+            return &this->pollfds[this->run_ctx_pollfd_idx.value()];
+        }
+
+        void setup_callbacks(VfioConsumer *callback_context)
+        {
+            int ret;
+            this->callback_context = callback_context;
+            // I think quiescing only applies when using vfu_add_to_sgl and
+            // vfu_sgl_read (see libvfio-user/docs/memory-mapping.md
+            // vfu_setup_device_quiesce_cb(this->vfu_ctx,
+            //      VfioUserServer::quiesce_cb);
+            ret = vfu_setup_device_reset_cb(this->vfu_ctx,
+                    VfioUserServer::reset_device_cb);
+            if (ret)
+                die("setting up reset callback for libvfio-user failed %d",
+                        ret);
+            vfu_setup_device_dma(this->vfu_ctx,
+                    VfioUserServer::dma_register_cb,
+                    VfioUserServer::dma_unregister_cb);
+            ret = vfu_setup_irq_state_callback(this->vfu_ctx, VFU_DEV_INTX_IRQ,
+                    VfioUserServer::intx_state_cb);
+            if (ret)
+                die("setting up intx state callback for libvfio-user failed");
+            ret = vfu_setup_irq_state_callback(this->vfu_ctx, VFU_DEV_MSIX_IRQ,
+                    VfioUserServer::msix_state_cb);
+            if (ret)
+                die("setting up msix state callback for libvfio-user failed");
+            // register unimplemented callback for all unused interrupt types
+            for (int type = 0; type < VFU_DEV_NUM_IRQS; type++) {
+                if (type == VFU_DEV_INTX_IRQ || type == VFU_DEV_MSIX_IRQ)
+                    continue;
+                ret = vfu_setup_irq_state_callback(this->vfu_ctx,
+                        (enum vfu_dev_irq_type) type,
+                        VfioUserServer::irq_state_unimplemented_cb);
+                if (ret)
+                    die("setting up irq type %d callback for libvfio-user \
+                            failed", type);
+            }
+        }
+
+    private:
+        static int reset_device_cb(vfu_ctx_t *vfu_ctx,
+                [[maybe_unused]] vfu_reset_type_t type)
+        {
+            VfioUserServer *vfu = (VfioUserServer*) vfu_get_private(vfu_ctx);
+            printf("resetting device\n"); // this happens at VM boot
+            vfu->callback_context->reset_device();
+            return 0;
+        }
+
+        static int quiesce_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx)
+        {
+            // See vfu_setup_device_quiesce_cb().
+            //VfioUserServer *vfu = (VfioUserServer*)vfu_get_private(vfu_ctx);
+            //vfu_quiesce_done(vfu.vfu_ctx, 0);
+            //die("quiesce_cb unimplemented");
+            printf("quiescing device. Not sure when this ends.\n");
+            return 0;
+        }
+
+        static void dma_register_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx,
+                [[maybe_unused]] vfu_dma_info_t *info)
+        {
+            printf("register dma cb\n");
+
+            //if ( //info->iova.iov_base == NULL ||
+            //    // TODO remove these checks as well
+            //    info->iova.iov_base == (void*)0xc0000 ||
+            //    info->iova.iov_base == (void*)0xe0000 )
+            //  return;
+
+            //__builtin_dump_struct(info, &printf);
+            VfioUserServer *vfu = (VfioUserServer*)vfu_get_private(vfu_ctx);
+            printf("{\n");
+            for(void* const& p: vfu->mapped){
+                printf("%p\n",p);
+            }
+            printf("}\n");
+            uint32_t flags = 0;
+            if (PROT_READ & info->prot)
+                flags |= VFIO_DMA_MAP_FLAG_READ;
+            if (PROT_WRITE & info->prot)
+                flags |= VFIO_DMA_MAP_FLAG_WRITE;
+            __builtin_dump_struct(info, &printf);
+
+            if (!info->vaddr){
+                //vfu_sgl_get failes if vaddr is NULL
+                printf("Region not mappable\n");
+                return;
+            }
+
+            //Map the region into the vmux Address Space
+            struct iovec* mapping =
+                (struct iovec*) calloc(1,sizeof(struct iovec));
+            dma_sg_t *sgl = (dma_sg_t*)calloc(1, dma_sg_size());
+            int ret = vfu_addr_to_sgl(vfu_ctx, info->iova.iov_base, 
+                    info->iova.iov_len, sgl, 1, flags);
+            if(ret < 0){
+                die("Failed to get sgl for DMA\n");
+            }
+
+            if(vfu_sgl_get(vfu_ctx ,sgl,mapping,1,0)){
+                die("Failed to populate iovec array");
+            }
+
+            printf("Add Address to mapped addresses\n");
+            vfu->sgs[info->vaddr] = sgl; 
+            vfu->mapped.insert(info->vaddr);
+            __builtin_dump_struct(info, &printf);
+            __builtin_dump_struct(mapping, &printf);
+
+            vfio_iommu_type1_dma_map dma_map = {
+                .argsz = sizeof(vfio_iommu_type1_dma_map),
+                .flags = flags,
+                .vaddr = (uint64_t)(info->vaddr),
+                .iova = (uint64_t)(info->iova.iov_base),
+                .size =  info->iova.iov_len,
+            };
+            __builtin_dump_struct(&dma_map, &printf);
+            vfu->callback_context->map_dma(&dma_map);
+        }
+
+        static void dma_unregister_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx,
+                [[maybe_unused]] vfu_dma_info_t *info)
+        {
+            printf("dma_unregister_cb\n");
+            // return;
+
+            // if (// info->iova.iov_base == NULL ||
+            //     info->iova.iov_base == (void*)0xc0000 ||
+            //     info->iova.iov_base == (void*)0xe0000 )
+            //   return;
+            __builtin_dump_struct(info, &printf);
+
+            VfioUserServer *vfu = (VfioUserServer*)vfu_get_private(vfu_ctx);
+            printf("{\n");
+            for(void* const& p: vfu->mapped){
+                printf("%p\n",p);
+            }
+            printf("}\n");
+
+            // info->mapping indicates if mapped
+            if(!info->mapping.iov_base){
+                printf("Region not mapped, nothing to do\n");
+                return;
+            }
+
+            if(!vfu->mapped.count(info->iova.iov_base)){
+                printf("Region seems not to be mapped\n");
+                //return;
+            }
+            if(vfu->sgs.count(info->vaddr)==1){
+                printf("dealloc sgl\n");
+            }
+            if(vfu->sgs.count(info->vaddr)>1){
+                printf("Why?\n");
+                //return;
+            }
+
+            vfio_iommu_type1_dma_unmap dma_unmap = {
+                .argsz = sizeof(vfio_iommu_type1_dma_unmap),
+                .flags = 0,
+                .iova = (uint64_t)(info->iova.iov_base),
+                .size = info->iova.iov_len,
+            };
+            vfu->callback_context->unmap_dma(&dma_unmap);
+        }
+
+        static void intx_state_cb(vfu_ctx_t *vfu_ctx, uint32_t start, uint32_t
+                count, bool mask)
+        {
+            VfioUserServer *vfu = (VfioUserServer*) vfu_get_private(vfu_ctx);
+            vfu->callback_context->mask_irqs(VFIO_PCI_INTX_IRQ_INDEX,
+                    start, count, mask);
+        }
+
+        static void msix_state_cb(
+                [[maybe_unused]] vfu_ctx_t *vfu_ctx,
+                [[maybe_unused]] uint32_t start,
+                [[maybe_unused]] uint32_t
+                count, [[maybe_unused]] bool mask
+                )
+        {
+            // masking of MSIx interrupts is unimplemented in linux/vfio
+            // (see vfio_pci_intrs.c:666)
+            printf("ignoring msix state cb (mask %u)\n", mask);
+            // TODO track maskedness of interrupts and make vmux apply the mask
+        }
+
+        static void irq_state_unimplemented_cb(
+                [[maybe_unused]] vfu_ctx_t *vfu_ctx,
+                [[maybe_unused]] uint32_t start,
+                [[maybe_unused]] uint32_t count,
+                [[maybe_unused]] bool mask
+                )
+        {
+            die("irq_state_unimplemented_cb unimplemented");
+        }
+
+        static ssize_t
+            unexpected_access_callback(
+                    [[maybe_unused]] vfu_ctx_t *vfu_ctx,
+                    [[maybe_unused]] char * const buf,
+                    [[maybe_unused]] size_t count,
+                    [[maybe_unused]] __loff_t offset,
+                    [[maybe_unused]] const bool is_write
+                    )
+            {
+                printf("Unexpectedly, a vfio register/DMA access callback was \
+                        triggered (at 0x%lx, is write %d.\n",
+                        offset, is_write);
+                return 0;
+            }
+
+        int add_region(struct vfio_region_info *region, int device_fd)
+        {
+            int ret;
+
+            if (region->size == 0) {
+                printf("Bar region %d skipped.\n", region->index);
+                return 0;
+            }
+
+            // set up dma VM<->vmux
+            struct iovec bar_mmap_areas[] = {
+                // no cb, just shmem
+                // { .iov_base  = (void*)region->offset,
+                // .iov_len = region->size}, 
+                { .iov_base  = (void*)0, .iov_len = region->size},
+            };
+            ret = vfu_setup_region(this->vfu_ctx, region->index,
+                    region->size, &(this->unexpected_access_callback),
+                    VFU_REGION_FLAG_RW | VFU_REGION_FLAG_MEM, bar_mmap_areas, 
+                    1, // nr. items in bar_mmap_areas
+                    device_fd, region->offset);
+            if (ret < 0) {
+                die("failed to setup BAR region %d", region->index);
+            }
+
+            // init some flags that are also set with qemu passthrough
+            vfu_pci_config_space_t *config_space =
+                vfu_pci_get_config_space(this->vfu_ctx);
+            vfu_bar_t *bar_config = &(config_space->hdr.bars[region->index]);
+            // see pci spec sec 7.5.1.2.1 for meaning of bits:
+            bar_config->mem.prefetchable = 1; // prefetchable
+            bar_config->mem.locatable = 0b10; // 64 bit
+
+            printf("Vfio-user: Bar region %d \
+                    (offset 0x%x, size 0x%x) set up.\n", region->index,
+                    (uint)region->offset, (uint)region->size);
+
+            return 0;
+        }
 };


### PR DESCRIPTION
This applies proper indentation and line wrapping to the vmux source code, and does not change anything semantically. E810 vmux passthrough works for me.