### PR TITLE
Use e810_bm

### DIFF
--- a/nix/vmux.nix
+++ b/nix/vmux.nix
@@ -7,7 +7,7 @@ let
     libvfio-user = fetchFromGitHub {
       owner = "vmuxIO";
       repo = "libvfio-user";
-      rev = "9a5124df49efed644f0db7e573ebd0367df480cd"; # master 09.06.22
+      rev = "9a5124df49efed644f0db7e573ebd0367df480cd"; # vmux branch 14.09.22
       #fetchSubmodules = true;
       sha256 = "sha256-v48G4GUzdHwdzZcpAjbZG3rutYR9rLXBqvx4clgB7kw=";
     };

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -133,6 +133,7 @@ class E810EmulatedDevice : public VmuxDevice {
 
   private:
     void init_general_callbacks(VfioUserServer &vfu) {
+      // TODO all those callback functions need implementation
       int ret;
       // I think quiescing only applies when using vfu_add_to_sgl and
       // vfu_sgl_read (see libvfio-user/docs/memory-mapping.md
@@ -176,20 +177,20 @@ class E810EmulatedDevice : public VmuxDevice {
     static int reset_device_cb(vfu_ctx_t *vfu_ctx,
             [[maybe_unused]] vfu_reset_type_t type)
     {
-      VfioUserServer *vfu = (VfioUserServer*) vfu_get_private(vfu_ctx);
+      E810EmulatedDevice *device = (E810EmulatedDevice*) vfu_get_private(vfu_ctx);
       printf("resetting device\n"); // this happens at VM boot
+      // device->model->SignalInterrupt(1, 1); // just as an example: do stuff
       return 0;
-      // TODO
     }
     static void dma_register_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx,
             [[maybe_unused]] vfu_dma_info_t *info)
     {
-      // TODO
+      printf("dma register cb\n");
     }
     static void dma_unregister_cb([[maybe_unused]] vfu_ctx_t *vfu_ctx,
             [[maybe_unused]] vfu_dma_info_t *info)
     {
-      // TODO
+      printf("dma unregister cb\n");
     }
     static void irq_state_unimplemented_cb(
             [[maybe_unused]] vfu_ctx_t *vfu_ctx,
@@ -198,7 +199,7 @@ class E810EmulatedDevice : public VmuxDevice {
             [[maybe_unused]] bool mask
             )
     {
-        die("irq_state_unimplemented_cb unimplemented");
+        printf("irq_state_unimplemented_cb unimplemented\n");
     }
 
     void init_bar_callbacks(VfioUserServer &vfu) {

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "sims/nic/e810_bm/e810_bm.h"
+#include "libsimbricks/simbricks/nicbm/nicbm.h"
 #include "util.hpp"
 #include "vfio-consumer.hpp"
 #include <cstdint>
@@ -61,6 +63,31 @@ class StubDevice : public VmuxDevice {
   public:
     StubDevice() {
       this->vfioc = NULL;
+    }
+};
+
+class E810EmulatedDevice : public VmuxDevice {
+  private:
+    std::unique_ptr<i40e::i40e_bm> model; // TODO rename i40e_bm class to e810
+
+  public:
+    E810EmulatedDevice() {
+      // printf("foobar %zu\n", nicbm::kMaxDmaLen);
+      // i40e::i40e_bm* model = new i40e::i40e_bm();
+      this->model = std::unique_ptr<i40e::i40e_bm>(new i40e::i40e_bm());
+      this->init_pci_ids();
+    }
+
+    void init_pci_ids() {
+      SimbricksProtoPcieDevIntro di = SimbricksProtoPcieDevIntro();
+      this->model->SetupIntro(di);
+      this->info.pci_vendor_id = di.pci_vendor_id;
+      this->info.pci_device_id = di.pci_device_id;
+      this->info.pci_class = di.pci_class;
+      this->info.pci_subclass = di.pci_subclass;
+      this->info.pci_revision = di.pci_revision;
+      __builtin_dump_struct(&di, &printf);
+      this->model->SetupIntro(di);
     }
 };
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -89,8 +89,8 @@ class E810EmulatedDevice : public VmuxDevice {
     E810EmulatedDevice() {
       // printf("foobar %zu\n", nicbm::kMaxDmaLen);
       // i40e::i40e_bm* model = new i40e::i40e_bm();
-      this->model = std::unique_ptr<i40e::i40e_bm>(new i40e::i40e_bm());
-      this->callbacks = std::shared_ptr<nicbm::CallbackAdaptor>(new nicbm::CallbackAdaptor());
+      this->model = std::make_unique<i40e::i40e_bm>();
+      this->callbacks = std::make_shared<nicbm::CallbackAdaptor>();
       this->model->vmux = this->callbacks;
       this->init_pci_ids();
     }

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -69,12 +69,15 @@ class StubDevice : public VmuxDevice {
 class E810EmulatedDevice : public VmuxDevice {
   private:
     std::unique_ptr<i40e::i40e_bm> model; // TODO rename i40e_bm class to e810
+    std::shared_ptr<nicbm::CallbackAdaptor> callbacks;
 
   public:
     E810EmulatedDevice() {
       // printf("foobar %zu\n", nicbm::kMaxDmaLen);
       // i40e::i40e_bm* model = new i40e::i40e_bm();
       this->model = std::unique_ptr<i40e::i40e_bm>(new i40e::i40e_bm());
+      this->callbacks = std::shared_ptr<nicbm::CallbackAdaptor>(new nicbm::CallbackAdaptor());
+      this->model->vmux = this->callbacks;
       this->init_pci_ids();
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,8 +156,11 @@ int _main(int argc, char** argv) {
         if (modes[i] == "passthrough") {
             device = std::shared_ptr<PassthroughDevice>(new PassthroughDevice(vfioc[i], pciAddresses[i]));
         }
-        if (modes[i] == "emulation") {
+        if (modes[i] == "stub") {
             device = std::shared_ptr<StubDevice>(new StubDevice());
+        }
+        if (modes[i] == "emulation") {
+            device = std::shared_ptr<E810EmulatedDevice>(new E810EmulatedDevice());
         }
         devices.push_back(device);
     }
@@ -218,21 +221,8 @@ void signal_handler(int) {
     quit.store(true);
 }
 
-void e810bmTesting() {
-    // printf("foobar %zu\n", nicbm::kMaxDmaLen);
-    // i40e::i40e_bm* model = new i40e::i40e_bm();
-    auto model = std::unique_ptr<i40e::i40e_bm>(new i40e::i40e_bm());
-    (void) model;
-
-    SimbricksProtoPcieDevIntro di = SimbricksProtoPcieDevIntro();
-    __builtin_dump_struct(&di, &printf);
-    model->SetupIntro(di);
-}
-
 
 int main(int argc, char** argv) {
-    e810bmTesting();
-
     // register signal handler to handle SIGINT gracefully to call destructors
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,7 @@ int _main(int argc, char** argv) {
             continue;
         }
         printf("Using: %s\n", pciAddresses[i].c_str());
-        vfioc.push_back(std::shared_ptr<VfioConsumer>(new VfioConsumer(pciAddresses[i].c_str())));
+        vfioc.push_back(std::make_shared<VfioConsumer>(pciAddresses[i].c_str()));
 
         if(vfioc[i]->init() < 0){
             die("failed to initialize vfio consumer");
@@ -154,13 +154,13 @@ int _main(int argc, char** argv) {
     for(size_t i = 0; i < pciAddresses.size(); i++) {
         std::shared_ptr<VmuxDevice> device;
         if (modes[i] == "passthrough") {
-            device = std::shared_ptr<PassthroughDevice>(new PassthroughDevice(vfioc[i], pciAddresses[i]));
+            device = std::make_shared<PassthroughDevice>(vfioc[i], pciAddresses[i]);
         }
         if (modes[i] == "stub") {
-            device = std::shared_ptr<StubDevice>(new StubDevice());
+            device = std::make_shared<StubDevice>();
         }
         if (modes[i] == "emulation") {
-            device = std::shared_ptr<E810EmulatedDevice>(new E810EmulatedDevice());
+            device = std::make_shared<E810EmulatedDevice>();
         }
         devices.push_back(device);
     }
@@ -169,7 +169,7 @@ int _main(int argc, char** argv) {
 
     for(size_t i = 0; i < pciAddresses.size(); i++){
         printf("Using: %s\n", pciAddresses[i].c_str());
-        runner.push_back(std::unique_ptr<VmuxRunner>(new VmuxRunner(sockets[i], devices[i], efd)));
+        runner.push_back(std::make_unique<VmuxRunner>(sockets[i], devices[i], efd));
         runner[i]->start();
 
         while(runner[i]->state !=2);

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -68,13 +68,6 @@ void VmuxRunner::initilize(){
     running.store(1);
 
     printf("initialize %s\n", vfu->sock.c_str());
-    vfu->vfu_ctx = vfu_create_ctx(
-            VFU_TRANS_SOCK,
-            vfu->sock.c_str(),
-            LIBVFIO_USER_FLAG_ATTACH_NB,
-            &vfu,
-            VFU_DEV_TYPE_PCI
-            );
 
     if (vfu->vfu_ctx == NULL) {
         die("failed to initialize device emulation");

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -92,11 +92,11 @@ void VmuxRunner::initilize(){
     }
 
     vfu_pci_set_id(vfu->vfu_ctx, device->info.pci_vendor_id, device->info.pci_device_id,
-            device->info.pci_class, device->info.pci_subclass);
+            device->info.pci_subsystem_vendor_id, device->info.pci_subsystem_id);
     vfu_pci_config_space_t *config_space =
         vfu_pci_get_config_space(vfu->vfu_ctx);
     config_space->hdr.rid = device->info.pci_revision;
-    vfu_pci_set_class(vfu->vfu_ctx, 0x02, 0x00, 0x00);
+    vfu_pci_set_class(vfu->vfu_ctx, device->info.pci_class, device->info.pci_subclass, device->info.pci_revision);
 
     this->device->setup_vfu(*vfu);
 

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -23,7 +23,7 @@ void VmuxRunner::run()
     state.store(INITILIZED);
     printf("%s: Waiting for qemu to attach...\n",this->socket.c_str());
     while(1){
-        int ret = vfu_attach_ctx(vfu.vfu_ctx);
+        int ret = vfu_attach_ctx(vfu->vfu_ctx);
         if (ret < 0) {
             usleep(10000);
 
@@ -37,7 +37,7 @@ void VmuxRunner::run()
     state.store(CONNECTED);
 
     struct pollfd pfd = (struct pollfd) {
-        .fd = vfu_get_poll_fd(vfu.vfu_ctx),
+        .fd = vfu_get_poll_fd(vfu->vfu_ctx),
             .events = POLLIN
     };
 
@@ -45,7 +45,7 @@ void VmuxRunner::run()
         int ret = poll(&pfd, 1, 500);
 
         if (pfd.revents & POLLIN) {
-            ret = vfu_run_ctx(vfu.vfu_ctx);
+            ret = vfu_run_ctx(vfu->vfu_ctx);
             if (ret < 0) {
                 if (errno == EAGAIN) {
                     continue;
@@ -67,42 +67,42 @@ void VmuxRunner::initilize(){
     state.store(STARTED);
     running.store(1);
 
-    printf("initialize %s\n", vfu.sock.c_str());
-    vfu.vfu_ctx = vfu_create_ctx(
+    printf("initialize %s\n", vfu->sock.c_str());
+    vfu->vfu_ctx = vfu_create_ctx(
             VFU_TRANS_SOCK,
-            vfu.sock.c_str(),
+            vfu->sock.c_str(),
             LIBVFIO_USER_FLAG_ATTACH_NB,
             &vfu,
             VFU_DEV_TYPE_PCI
             );
 
-    if (vfu.vfu_ctx == NULL) {
+    if (vfu->vfu_ctx == NULL) {
         die("failed to initialize device emulation");
     }
 
-    int ret = vfu_setup_log(vfu.vfu_ctx, _log, LOG_DEBUG);
+    int ret = vfu_setup_log(vfu->vfu_ctx, _log, LOG_DEBUG);
     if (ret < 0) {
         die("failed to setup log");
     }
 
-    ret = vfu_pci_init(vfu.vfu_ctx, VFU_PCI_TYPE_EXPRESS,
+    ret = vfu_pci_init(vfu->vfu_ctx, VFU_PCI_TYPE_EXPRESS,
             PCI_HEADER_TYPE_NORMAL, 0); // maybe 4?
     if (ret < 0) {
         die("vfu_pci_init() failed") ;
     }
 
-    vfu_pci_set_id(vfu.vfu_ctx, device->info.pci_vendor_id, device->info.pci_device_id,
+    vfu_pci_set_id(vfu->vfu_ctx, device->info.pci_vendor_id, device->info.pci_device_id,
             device->info.pci_class, device->info.pci_subclass);
     vfu_pci_config_space_t *config_space =
-        vfu_pci_get_config_space(vfu.vfu_ctx);
+        vfu_pci_get_config_space(vfu->vfu_ctx);
     config_space->hdr.rid = device->info.pci_revision;
-    vfu_pci_set_class(vfu.vfu_ctx, 0x02, 0x00, 0x00);
+    vfu_pci_set_class(vfu->vfu_ctx, 0x02, 0x00, 0x00);
 
     // set up vfio-user DMA
 
     if (device->vfioc != NULL) {
         // pass through registers, only if it is a passthrough device
-        ret = vfu.add_regions(device->vfioc->regions, device->vfioc->device);
+        ret = vfu->add_regions(device->vfioc->regions, device->vfioc->device);
         if (ret < 0)
             die("failed to add regions");
     }
@@ -110,13 +110,13 @@ void VmuxRunner::initilize(){
     // set up irqs 
 
     if (device->vfioc != NULL) {
-        ret = vfu.add_irqs(device->vfioc->interrupts);
+        ret = vfu->add_irqs(device->vfioc->interrupts);
         if (ret < 0)
             die("failed to add irqs");
 
-        vfu.add_legacy_irq_pollfds(device->vfioc->irqfd_intx, device->vfioc->irqfd_msi,
+        vfu->add_legacy_irq_pollfds(device->vfioc->irqfd_intx, device->vfioc->irqfd_msi,
                 device->vfioc->irqfd_err, device->vfioc->irqfd_req);
-        vfu.add_msix_pollfds(device->vfioc->irqfds);
+        vfu->add_msix_pollfds(device->vfioc->irqfds);
     }
 
     if (device->vfioc != NULL) {
@@ -124,10 +124,10 @@ void VmuxRunner::initilize(){
             this->add_caps(device->vfioc);
         }
 
-        vfu.setup_callbacks(device->vfioc);
+        vfu->setup_callbacks(device->vfioc);
     }
 
-    ret = vfu_realize_ctx(vfu.vfu_ctx);
+    ret = vfu_realize_ctx(vfu->vfu_ctx);
     if (ret < 0) {
         die("failed to realize device");
     }
@@ -139,13 +139,13 @@ void VmuxRunner::add_caps(shared_ptr<VfioConsumer> vfioc) {
   void *cap_data;
 
   cap_data = caps->pm();
-  int ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, 0, cap_data);
+  int ret = vfu_pci_add_capability(vfu->vfu_ctx, 0, 0, cap_data);
   if (ret < 0)
     die("add cap error");
   free(cap_data);
 
   cap_data = caps->msix();
-  ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, 0, cap_data);
+  ret = vfu_pci_add_capability(vfu->vfu_ctx, 0, 0, cap_data);
   if (ret < 0)
     die("add cap error");
   free(cap_data);
@@ -159,7 +159,7 @@ void VmuxRunner::add_caps(shared_ptr<VfioConsumer> vfioc) {
   // free(cap_data);
 
   cap_data = caps->exp();
-  ret = vfu_pci_add_capability(vfu.vfu_ctx, 0, VFU_CAP_FLAG_READONLY, cap_data);
+  ret = vfu_pci_add_capability(vfu->vfu_ctx, 0, VFU_CAP_FLAG_READONLY, cap_data);
   if (ret < 0)
     die("add cap error");
   free(cap_data);
@@ -174,7 +174,7 @@ void VmuxRunner::add_caps(shared_ptr<VfioConsumer> vfioc) {
 
   cap_data = caps->dsn();
   ret = vfu_pci_add_capability(
-      vfu.vfu_ctx, 0, VFU_CAP_FLAG_READONLY | VFU_CAP_FLAG_EXTENDED, cap_data);
+      vfu->vfu_ctx, 0, VFU_CAP_FLAG_READONLY | VFU_CAP_FLAG_EXTENDED, cap_data);
   if (ret < 0)
     die("add cap error");
   free(cap_data);

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -106,8 +106,8 @@ void VmuxRunner::initilize(){
 }
 
 void VmuxRunner::add_caps(shared_ptr<VfioConsumer> vfioc) {
-  std::shared_ptr<Capabilities> caps = std::shared_ptr<Capabilities>(
-      new Capabilities(&(vfioc->regions[VFU_PCI_DEV_CFG_REGION_IDX]), vfioc->device_name));
+  std::shared_ptr<Capabilities> caps = std::make_shared<Capabilities>(
+      &(vfioc->regions[VFU_PCI_DEV_CFG_REGION_IDX]), vfioc->device_name);
   void *cap_data;
 
   cap_data = caps->pm();

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -98,33 +98,12 @@ void VmuxRunner::initilize(){
     config_space->hdr.rid = device->info.pci_revision;
     vfu_pci_set_class(vfu->vfu_ctx, 0x02, 0x00, 0x00);
 
-    // set up vfio-user DMA
-
-    if (device->vfioc != NULL) {
-        // pass through registers, only if it is a passthrough device
-        ret = vfu->add_regions(device->vfioc->regions, device->vfioc->device);
-        if (ret < 0)
-            die("failed to add regions");
-    }
-
-    // set up irqs 
-
-    if (device->vfioc != NULL) {
-        ret = vfu->add_irqs(device->vfioc->interrupts);
-        if (ret < 0)
-            die("failed to add irqs");
-
-        vfu->add_legacy_irq_pollfds(device->vfioc->irqfd_intx, device->vfioc->irqfd_msi,
-                device->vfioc->irqfd_err, device->vfioc->irqfd_req);
-        vfu->add_msix_pollfds(device->vfioc->irqfds);
-    }
+    this->device->setup_vfu(*vfu);
 
     if (device->vfioc != NULL) {
         if(device->vfioc->is_pcie){
             this->add_caps(device->vfioc);
         }
-
-        vfu->setup_callbacks(device->vfioc);
     }
 
     ret = vfu_realize_ctx(vfu->vfu_ctx);

--- a/src/runner.hpp
+++ b/src/runner.hpp
@@ -31,7 +31,7 @@ class VmuxRunner{
                 int efd): device(device) {
             state.store(0);
             this->socket = socket;
-            this->vfu = std::make_shared<VfioUserServer>(socket, efd);
+            this->vfu = std::make_shared<VfioUserServer>(socket, efd, device);
         }
 
         void start(){

--- a/src/runner.hpp
+++ b/src/runner.hpp
@@ -10,7 +10,7 @@
 
 class VmuxRunner{
     public: 
-        VfioUserServer vfu;
+        std::shared_ptr<VfioUserServer> vfu;
         std::shared_ptr<VmuxDevice> device;
         std::thread runner;
         std::shared_ptr<Capabilities> caps;
@@ -28,9 +28,10 @@ class VmuxRunner{
         };
 
         VmuxRunner(std::string socket, std::shared_ptr<VmuxDevice> device, 
-                int efd): vfu(socket,efd), device(device) {
+                int efd): device(device) {
             state.store(0);
             this->socket = socket;
+            this->vfu = std::shared_ptr<VfioUserServer>(new VfioUserServer(socket, efd));
         }
 
         void start(){
@@ -50,9 +51,6 @@ class VmuxRunner{
         }
         bool is_connected(){
             return state == CONNECTED;
-        }
-        VfioUserServer& get_interrupts(){
-            return vfu;
         }
 
     private:

--- a/src/runner.hpp
+++ b/src/runner.hpp
@@ -31,7 +31,7 @@ class VmuxRunner{
                 int efd): device(device) {
             state.store(0);
             this->socket = socket;
-            this->vfu = std::shared_ptr<VfioUserServer>(new VfioUserServer(socket, efd));
+            this->vfu = std::make_shared<VfioUserServer>(socket, efd);
         }
 
         void start(){

--- a/src/sims/nic/e810_bm/base/ice_lan_tx_rx.h
+++ b/src/sims/nic/e810_bm/base/ice_lan_tx_rx.h
@@ -3,6 +3,9 @@
 
 #ifndef _ICE_LAN_TX_RX_H_
 #define _ICE_LAN_TX_RX_H_
+
+#include <linux/types.h>
+
 typedef uint8_t u8;
 typedef uint16_t u16;
 typedef uint32_t u32;

--- a/src/sims/nic/e810_bm/e810_base_wrapper.h
+++ b/src/sims/nic/e810_bm/e810_base_wrapper.h
@@ -5,6 +5,7 @@
 #ifndef I40E_BASE_WRAPPER_H_
 #define I40E_BASE_WRAPPER_H_
 
+#include <linux/types.h>
 #include <stdint.h>
 
 #define PF_DRIVER

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -41,7 +41,7 @@ std::vector<int> get_hardware_ids(std::string pci_device,
         "subsystem_vendor", "subsystem_device"};
     std::vector<int> result;
     int bytes_read;
-    char id_buffer[7];
+    char id_buffer[7] = {0};
     FILE* id;
 
     for(size_t i = 0; i < values.size(); i++ ){

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -64,3 +64,15 @@ std::vector<int> get_hardware_ids(std::string pci_device,
 
     return result;
 }
+
+/* convert simbricks bar flags (SIMBRICKS_PROTO_PCIE_BAR_*) to vfio-user flags (VFU_REGION_FLAG_*) */
+int convert_flags(int bricks) {
+    int vfu = 0;
+    
+    // if BAR_IO (port io) is not set, it is FLAG_MEM (MMIO)
+    if (!(bricks & SIMBRICKS_PROTO_PCIE_BAR_IO)) {
+        vfu &= VFU_REGION_FLAG_MEM;
+    }
+
+    return vfu;
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -71,7 +71,7 @@ int convert_flags(int bricks) {
     
     // if BAR_IO (port io) is not set, it is FLAG_MEM (MMIO)
     if (!(bricks & SIMBRICKS_PROTO_PCIE_BAR_IO)) {
-        vfu &= VFU_REGION_FLAG_MEM;
+        vfu |= VFU_REGION_FLAG_MEM;
     }
 
     return vfu;

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -5,6 +5,8 @@
 #include <dirent.h>
 #include <vector> 
 #include <cstring>
+#include "src/libsimbricks/simbricks/pcie/proto.h"
+#include "libvfio-user.h"
 
 // as per PCI spec, there can be at most 2048 MSIx inerrupts per device
 #define PCI_MSIX_MAX 2048
@@ -20,3 +22,5 @@ std::string get_iommu_group(std::string pci_device);
 
 std::vector<int> get_hardware_ids(std::string pci_device,
         std::string iommu_group);
+
+int convert_flags(int bricks);

--- a/src/vfio-server.hpp
+++ b/src/vfio-server.hpp
@@ -58,7 +58,7 @@ class VfioUserServer {
         size_t irq_err_pollfd_idx; // only one
         size_t irq_req_pollfd_idx; // only one
         std::vector<struct pollfd> pollfds;
-        std::shared_ptr<VfioConsumer> callback_context;
+        std::shared_ptr<VfioConsumer> callback_context; // may actually be NULL!
         std::set<void*> mapped;
         std::map<void*, dma_sg_t*> sgs;
 
@@ -108,6 +108,7 @@ class VfioUserServer {
             }
         }
 
+        /* set up regions as passthrough */
         int add_regions(std::vector<struct vfio_region_info> regions,
                 int device_fd)
         {

--- a/src/vfio-server.hpp
+++ b/src/vfio-server.hpp
@@ -322,9 +322,12 @@ class VfioUserServer {
             if (ret)
                 die("setting up reset callback for libvfio-user failed %d",
                         ret);
-            vfu_setup_device_dma(this->vfu_ctx,
+            ret = vfu_setup_device_dma(this->vfu_ctx,
                     VfioUserServer::dma_register_cb,
                     VfioUserServer::dma_unregister_cb);
+              if (ret)
+                    die("setting up dma callback for libvfio-user failed %d",
+                          ret);
             ret = vfu_setup_irq_state_callback(this->vfu_ctx, VFU_DEV_INTX_IRQ,
                     VfioUserServer::intx_state_cb);
             if (ret)

--- a/src/vfio-server.hpp
+++ b/src/vfio-server.hpp
@@ -84,6 +84,13 @@ class VfioUserServer {
                             this->sock.c_str());
                 }
             }
+            this->vfu_ctx = vfu_create_ctx(
+                VFU_TRANS_SOCK,
+                this->sock.c_str(),
+                LIBVFIO_USER_FLAG_ATTACH_NB,
+                this,
+                VFU_DEV_TYPE_PCI
+                );
         }
 
         ~VfioUserServer() {

--- a/src/vfio-server.hpp
+++ b/src/vfio-server.hpp
@@ -301,7 +301,7 @@ class VfioUserServer {
             return &this->pollfds[this->run_ctx_pollfd_idx.value()];
         }
 
-        void setup_callbacks(std::shared_ptr<VfioConsumer> callback_context)
+        void setup_passthrough_callbacks(std::shared_ptr<VfioConsumer> callback_context)
         {
             int ret;
             this->callback_context = callback_context;


### PR DESCRIPTION
seperate emulation and passthrough code: E810EmulatedDevice vs PassthroughDevice

While E810 emulation does not fully use the behavioural model yet, it can already be used as a POC for how to implement emulation. 