### PR TITLE
build dpvs for e810

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
     flakepkgs = self.packages.${system};
     mydpdk = pkgs.callPackage ./nix/dpdk.nix {
       kernel = pkgs.linuxPackages_5_10.kernel;
+      inherit (flakepkgs) linux-firmware-pinned;
     };
     selfpkgs = self.packages.${system};
     # make-disk-image = import (pkgs.path + "/nixos/lib/make-disk-image.nix");
@@ -102,6 +103,11 @@
         inherit self;
       };
       dpdk = mydpdk;
+      dpvs = pkgs.callPackage ./nix/dpvs.nix {
+        linux = pkgs.linuxPackages_5_10.kernel;
+        inherit (flakepkgs) linux-firmware-pinned;
+        inherit self;
+      };
       pktgen = pkgs.callPackage ./nix/pktgen.nix {
         dpdk = mydpdk;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -65,9 +65,7 @@
     flake-utils,
     nixos-generators,
     ...
-  } @ args: let
-  in
-  (flake-utils.lib.eachSystem ["x86_64-linux"] (system:
+  } @ args: (flake-utils.lib.eachSystem ["x86_64-linux"] (system:
   let
     pkgs = nixpkgs.legacyPackages.${system};
     pkgs2211 = args.nixpkgs-2211.legacyPackages.${system};
@@ -108,8 +106,6 @@
         dpvs-version = true;
       };
       dpvs = pkgs.callPackage ./nix/dpvs.nix {
-        linux = pkgs.linuxPackages_5_10.kernel;
-        inherit (flakepkgs) linux-firmware-pinned;
         inherit self;
       };
       pktgen = pkgs.callPackage ./nix/pktgen.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -73,10 +73,6 @@
     pkgs2211 = args.nixpkgs-2211.legacyPackages.${system};
     pkgs2111 = args.nixpkgs-2111.legacyPackages.${system};
     flakepkgs = self.packages.${system};
-    mydpdk = pkgs.callPackage ./nix/dpdk.nix {
-      kernel = pkgs.linuxPackages_5_10.kernel;
-      inherit (flakepkgs) linux-firmware-pinned;
-    };
     selfpkgs = self.packages.${system};
     # make-disk-image = import (pkgs.path + "/nixos/lib/make-disk-image.nix");
     make-disk-image = import (./nix/make-disk-image.nix);
@@ -102,14 +98,22 @@
         inherit (flakepkgs) linux-firmware-pinned;
         inherit self;
       };
-      dpdk = mydpdk;
+      dpdk = pkgs.callPackage ./nix/dpdk.nix {
+        kernel = pkgs.linuxPackages_5_10.kernel;
+        inherit (flakepkgs) linux-firmware-pinned;
+      };
+      dpdk-dpvs = pkgs.callPackage ./nix/dpdk.nix {
+        kernel = pkgs.linuxPackages_5_10.kernel;
+        inherit (flakepkgs) linux-firmware-pinned;
+        dpvs-version = true;
+      };
       dpvs = pkgs.callPackage ./nix/dpvs.nix {
         linux = pkgs.linuxPackages_5_10.kernel;
         inherit (flakepkgs) linux-firmware-pinned;
         inherit self;
       };
       pktgen = pkgs.callPackage ./nix/pktgen.nix {
-        dpdk = mydpdk;
+        dpdk = selfpkgs.dpdk;
       };
 
       # util

--- a/justfile
+++ b/justfile
@@ -392,6 +392,15 @@ trex_ieee1588:
   cd automation/trex_control_plane/interactive/
   python3 udp_1pkt_src_ip_split_latency_ieee_1588.py
 
+dpvs:
+  just prepare
+  echo 8192 | sudo tee /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+  echo 8192 | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
+  sudo mount -t hugetlbfs -o pagesize=2M nodev /tmp/mnt
+  echo spawn exactly one VF and bind it to vfio
+  echo make sure dpdk-devbind only detects exactly one compatible device (otherwise dpvs fails)
+  sudo modprobe rte_kni carrier=on
+
 vfio-user-server:
   qemu-system-x86_64 \
   -machine x-remote,vfio-user=on \

--- a/justfile
+++ b/justfile
@@ -400,6 +400,9 @@ dpvs:
   echo spawn exactly one VF and bind it to vfio
   echo make sure dpdk-devbind only detects exactly one compatible device (otherwise dpvs fails)
   sudo modprobe rte_kni carrier=on
+  echo with E810 VF (iavf) the following inits and starts polling
+  echo with E810 PF (ice) the following inits and start polling, but seems to use some fallback function (NETIF: dpdk_set_mc_list: rte_eth_dev_set_mc_addr_list is not supported, enable all multicast.)
+  sudo ./result/bin/dpvs -c ./nix/dpvs.conf.single-nic.sample -- -l 0-8
 
 vfio-user-server:
   qemu-system-x86_64 \

--- a/nix/dpdk.nix
+++ b/nix/dpdk.nix
@@ -5,19 +5,24 @@
 , libbsd, numactl, libbpf, zlib, libelf, jansson, openssl, libpcap
 , doxygen, python3
 , withExamples ? []
-, shared ? false 
-, linux-firmware-pinned}:
+, shared ? false
+, linux-firmware-pinned
+, dpvs-version ? true}:
 
 let
   mod = false; #kernel != null;
-  dpdkVersion = "20.11.9";
+  dpdkVersion = if dpvs-version then "20.11.9" else "21.05";
+  dpdk-sha = if dpvs-version then
+    "sha256-ji+6fx/G+6MQHf+Ke8dstE8h14W8S+mVUE3xFQVWn30="
+    else
+    "sha256-HhJJm0xfzbV8g+X+GE6mvs3ffPCSiTwsXvLvsO7BLws=";
 in stdenv.mkDerivation rec {
   pname = "dpdk";
   version = "${dpdkVersion}" + lib.optionalString mod "-${kernel.version}";
 
   src = fetchurl {
     url = "https://fast.dpdk.org/rel/dpdk-${dpdkVersion}.tar.xz";
-    sha256 = "sha256-ji+6fx/G+6MQHf+Ke8dstE8h14W8S+mVUE3xFQVWn30=";
+    sha256 = dpdk-sha;
   };
 
   nativeBuildInputs = [
@@ -40,13 +45,14 @@ in stdenv.mkDerivation rec {
     zlib
   ] ++ lib.optionals mod kernel.moduleBuildDependencies;
 
-  patches = [
-    # ./dpdk-new-meson.patch
+  patches = lib.optionals (lib.versionAtLeast dpdkVersion "21.0.0") [
+    ./dpdk-new-meson.patch # tested with dpdk 21.05
   ];
 
   postPatch = ''
     patchShebangs config/arm buildtools
     ls -la drivers/net/ice/ice_ethdev.c
+
     substituteInPlace drivers/net/ice/ice_ethdev.h \
       --replace '#define ICE_PKG_FILE_DEFAULT "/lib/firmware/intel/ice/ddp/ice.pkg"' \
       '#define ICE_PKG_FILE_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/ice-1.3.26.0.pkg"'
@@ -58,12 +64,6 @@ in stdenv.mkDerivation rec {
 #define ICE_PKG_FILE_UPDATES "/lib/firmware/updates/intel/ice/ddp/ice.pkg"                    
 #define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/"    
 #define ICE_PKG_FILE_SEARCH_PATH_UPDATES "/lib/firmware/updates/intel/ice/ddp/"               
-
-    substituteInPlace lib/librte_mbuf/rte_mbuf_dyn.h \
-      --replace "#include <sys/types.h>
-    " "#include <sys/types.h>
-    #include <stdint.h>
-    "
   '';
 
   mesonFlags = [
@@ -91,16 +91,8 @@ in stdenv.mkDerivation rec {
     rm -f $kmod/lib/modules/${kernel.modDirVersion}/build
   '';
 
-  postInstall = (lib.optionalString (withExamples != []) ''
+  postInstall = lib.optionalString (withExamples != []) ''
     find examples -type f -executable -exec install {} $out/bin \;
-  '') + ''
-    pwd
-    ls
-    # substituteInPlace include/rte_mbuf_dyn.h \
-    #   --replace "#include <sys/types.h>
-    # " "#include <sys/types.h>
-    # #include <stdint.h>
-    # "
   '';
 
   outputs = [ "out" ] ++ lib.optional mod "kmod";

--- a/nix/dpdk.nix
+++ b/nix/dpdk.nix
@@ -5,18 +5,19 @@
 , libbsd, numactl, libbpf, zlib, libelf, jansson, openssl, libpcap
 , doxygen, python3
 , withExamples ? []
-, shared ? false }:
+, shared ? false 
+, linux-firmware-pinned}:
 
 let
   mod = false; #kernel != null;
-  dpdkVersion = "21.05";
+  dpdkVersion = "20.11.9";
 in stdenv.mkDerivation rec {
   pname = "dpdk";
   version = "${dpdkVersion}" + lib.optionalString mod "-${kernel.version}";
 
   src = fetchurl {
     url = "https://fast.dpdk.org/rel/dpdk-${dpdkVersion}.tar.xz";
-    sha256 = "sha256-HhJJm0xfzbV8g+X+GE6mvs3ffPCSiTwsXvLvsO7BLws=";
+    sha256 = "sha256-ji+6fx/G+6MQHf+Ke8dstE8h14W8S+mVUE3xFQVWn30=";
   };
 
   nativeBuildInputs = [
@@ -40,7 +41,7 @@ in stdenv.mkDerivation rec {
   ] ++ lib.optionals mod kernel.moduleBuildDependencies;
 
   patches = [
-    ./dpdk-new-meson.patch
+    # ./dpdk-new-meson.patch
   ];
 
   postPatch = ''
@@ -48,16 +49,21 @@ in stdenv.mkDerivation rec {
     ls -la drivers/net/ice/ice_ethdev.c
     substituteInPlace drivers/net/ice/ice_ethdev.h \
       --replace '#define ICE_PKG_FILE_DEFAULT "/lib/firmware/intel/ice/ddp/ice.pkg"' \
-      '#define ICE_PKG_FILE_DEFAULT "/scratch/okelmann/linux-firmware/intel/ice/ddp/ice-1.3.26.0.pkg"'
+      '#define ICE_PKG_FILE_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/ice-1.3.26.0.pkg"'
     substituteInPlace drivers/net/ice/ice_ethdev.h --replace \
       '#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "/lib/firmware/intel/ice/ddp/"' \
-      '#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "/scratch/okelmann/linux-firmware/intel/ice/ddp/"'
+      '#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/"'
     #exit 1
-#define ICE_PKG_FILE_DEFAULT "/scratch/okelmann/linux-firmware/intel/ice/ddp/ice-1.3.26.0.pkg"
+#define ICE_PKG_FILE_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/ice-1.3.26.0.pkg"
 #define ICE_PKG_FILE_UPDATES "/lib/firmware/updates/intel/ice/ddp/ice.pkg"                    
-#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "/scratch/okelmann/linux-firmware/intel/ice/ddp/"    
+#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/"    
 #define ICE_PKG_FILE_SEARCH_PATH_UPDATES "/lib/firmware/updates/intel/ice/ddp/"               
 
+    substituteInPlace lib/librte_mbuf/rte_mbuf_dyn.h \
+      --replace "#include <sys/types.h>
+    " "#include <sys/types.h>
+    #include <stdint.h>
+    "
   '';
 
   mesonFlags = [
@@ -85,8 +91,16 @@ in stdenv.mkDerivation rec {
     rm -f $kmod/lib/modules/${kernel.modDirVersion}/build
   '';
 
-  postInstall = lib.optionalString (withExamples != []) ''
+  postInstall = (lib.optionalString (withExamples != []) ''
     find examples -type f -executable -exec install {} $out/bin \;
+  '') + ''
+    pwd
+    ls
+    # substituteInPlace include/rte_mbuf_dyn.h \
+    #   --replace "#include <sys/types.h>
+    # " "#include <sys/types.h>
+    # #include <stdint.h>
+    # "
   '';
 
   outputs = [ "out" ] ++ lib.optional mod "kmod";

--- a/nix/dpvs.conf.single-nic.sample
+++ b/nix/dpvs.conf.single-nic.sample
@@ -1,0 +1,264 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! This is dpvs default configuration file.
+!
+! The attribute "<init>" denotes the configuration item at initialization stage. Item of
+! this type is configured oneshoot and not reloadable. If invalid value configured in the
+! file, dpvs would use its default value.
+!
+! Note that dpvs configuration file supports the following comment type:
+!   * line comment: using '#" or '!'
+!   * inline range comment: using '<' and '>', put comment in between
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+! global config
+global_defs {
+    log_level   DEBUG
+    ! log_file    /var/log/dpvs.log
+    ! log_async_mode    on
+    ! kni               off
+}
+
+! netif config
+netif_defs {
+    <init> pktpool_size     524287
+    <init> pktpool_cache    256
+
+    <init> device dpdk0 {
+        rx {
+            queue_number        8
+            descriptor_number   1024
+            rss                 ip
+        }
+        tx {
+            queue_number        8
+            descriptor_number   1024
+        }
+        ! mtu                   1500
+        ! promisc_mode            disable
+        kni_name                dpdk0.kni
+    }
+}
+
+! worker config (lcores)
+worker_defs {
+    <init> worker cpu0 {
+        type    master
+        cpu_id  0
+    }
+
+    <init> worker cpu1 {
+        type    slave
+        cpu_id  1
+        port    dpdk0 {
+            rx_queue_ids     0
+            tx_queue_ids     0
+            ! isol_rx_cpu_ids  9
+            ! isol_rxq_ring_sz 1048576
+        }
+    }
+
+    <init> worker cpu2 {
+        type    slave
+        cpu_id  2
+        port    dpdk0 {
+            rx_queue_ids     1
+            tx_queue_ids     1
+            ! isol_rx_cpu_ids  10
+            ! isol_rxq_ring_sz 1048576
+        }
+    }
+
+    <init> worker cpu3 {
+        type        slave
+        cpu_id      3
+        port        dpdk0 {
+            rx_queue_ids     2
+            tx_queue_ids     2
+            ! isol_rx_cpu_ids  11
+            ! isol_rxq_ring_sz 1048576
+        }
+    }
+
+    <init> worker   cpu4 {
+        type        slave
+        cpu_id      4
+        port        dpdk0 {
+            rx_queue_ids     3
+            tx_queue_ids     3
+            ! isol_rx_cpu_ids  12
+            ! isol_rxq_ring_sz 1048576
+        }
+    }
+
+    <init> worker   cpu5 {
+        type        slave
+        cpu_id      5
+        port        dpdk0 {
+            rx_queue_ids     4
+            tx_queue_ids     4
+            ! isol_rx_cpu_ids  13
+            ! isol_rxq_ring_sz 1048576
+        }
+    }
+
+    <init> worker   cpu6 {
+        type        slave
+        cpu_id      6
+        port        dpdk0 {
+            rx_queue_ids     5
+            tx_queue_ids     5
+            ! isol_rx_cpu_ids  14
+            ! isol_rxq_ring_sz 1048576
+        }
+    }
+
+    <init> worker   cpu7 {
+        type        slave
+        cpu_id      7
+        port        dpdk0 {
+            rx_queue_ids     6
+            tx_queue_ids     6
+            ! isol_rx_cpu_ids  15
+            ! isol_rxq_ring_sz 1048576
+        }
+    }
+
+    <init> worker   cpu8 {
+        type        slave
+        cpu_id      8
+        ! icmp_redirect_core
+        port        dpdk0 {
+            rx_queue_ids     7
+            tx_queue_ids     7
+            ! isol_rx_cpu_ids  16
+            ! isol_rxq_ring_sz 1048576
+        }
+    }
+
+    !<init> worker   cpu17 {
+    !    type        kni
+    !    cpu_id      17
+    !    port        dpdk0 {
+    !        rx_queue_ids     8
+    !        tx_queue_ids     8
+    !    }
+    !}
+}
+
+! timer config
+timer_defs {
+    # cpu job loops to schedule dpdk timer management
+    schedule_interval    500
+}
+
+! dpvs neighbor config
+neigh_defs {
+    <init> unres_queue_length  128
+    timeout                    60
+}
+
+! dpvs ipset config
+ipset_defs {
+    <init> ipset_hash_pool_size 131072
+}
+
+! dpvs ipv4 config
+ipv4_defs {
+    forwarding                 off
+    <init> default_ttl         64
+    fragment {
+        <init> bucket_number   4096
+        <init> bucket_entries  16
+        <init> max_entries     4096
+        <init> ttl             1
+    }
+}
+
+! dpvs ipv6 config
+ipv6_defs {
+    disable                     off
+    forwarding                  off
+    route6 {
+        <init> method           hlist
+        recycle_time            10
+    }
+}
+
+! control plane config
+ctrl_defs {
+    lcore_msg {
+        <init> ring_size                4096
+        sync_msg_timeout_us             20000
+        priority_level                  low
+    }
+    ipc_msg {
+        <init> unix_domain /var/run/dpvs_ctrl
+    }
+}
+
+! ipvs config
+ipvs_defs {
+    conn {
+        <init> conn_pool_size       2097152
+        <init> conn_pool_cache      256
+        conn_init_timeout           3
+        ! expire_quiescent_template
+        ! fast_xmit_close
+        ! <init> redirect           off
+    }
+
+    udp {
+        ! defence_udp_drop
+        uoa_mode        opp
+        uoa_max_trail   3
+        timeout {
+            normal      300
+            last        3
+        }
+    }
+
+    tcp {
+        ! defence_tcp_drop
+        timeout {
+            none        2
+            established 90
+            syn_sent    3
+            syn_recv    30
+            fin_wait    7
+            time_wait   7
+            close       3
+            close_wait  7
+            last_ack    7
+            listen      120
+            synack      30
+            last        2
+        }
+        synproxy {
+            synack_options {
+                mss             1452
+                ttl             63
+                sack
+                ! wscale
+                ! timestamp
+            }
+            close_client_window
+            ! defer_rs_syn
+            rs_syn_max_retry    3
+            ack_storm_thresh    10
+            max_ack_saved       3
+            conn_reuse_state {
+                close
+                time_wait
+                ! fin_wait
+                ! close_wait
+                ! last_ack
+           }
+        }
+    }
+}
+
+! sa_pool config
+sa_pool {
+    pool_hash_size  16
+    flow_enable     on
+}

--- a/nix/dpvs.nix
+++ b/nix/dpvs.nix
@@ -127,12 +127,6 @@ stdenv.mkDerivation {
     substituteInPlace ./src/netif.c \
       --replace "return rss_value;" "return rss_value & (!ETH_RSS_IPV6_EX); // ignore this one feature not supported by E810"
 
-    # dpvs sample config crashes, if not all cores are configured. Sample config uses 9 cores.
-    substituteInPlace ./src/config.mk \
-      --replace 'DPVS_MAX_LCORE=64' 'DPVS_MAX_LCORE=9'
-    substituteInPlace ./src/ctrl.c \
-      --replace 'MSG_MAX_LCORE_SUPPORTED 64' 'MSG_MAX_LCORE_SUPPORTED 9'
-
     substituteInPlace ./dpdk-result/lib/pkgconfig/libdpdk.pc \
       --replace "${dpdk}" "$sourceRoot/dpdk-result"
   '';

--- a/nix/dpvs.nix
+++ b/nix/dpvs.nix
@@ -1,95 +1,55 @@
 { self
-,stdenv
-, fetchFromGitHub
-, fetchurl
-, writeScriptBin
-, linux
-, openssl
-, tbb
-, libbsd
-, numactl
-, luajit
-, hello
-, cmake
-, ninja
-, meson
-, bash
-, gcc8Stdenv
-, libpcap
-, python3Packages
-, linux-firmware-pinned
 , system
 , pkgs
-}:
+, ...}:
 let 
-  srcpack = {
-    dpvs = fetchFromGitHub {
-      owner = "iqiyi";
-      repo = "dpvs";
-      rev = "v1.9.4";
-      sha256 = "sha256-PSBApG2Ix/peh2+FZxz7PjK1f+JbNmL1l6aNpEhLslY=";
-    };
-    dpdk = self.inputs.dpdk-lachnit-src;
-  };
   dpdk = self.outputs.packages.${system}.dpdk-dpvs;
 in
-stdenv.mkDerivation {
+pkgs.stdenv.mkDerivation {
   pname = "dpvs";
   version = "2023-09-21";
 
-  src = srcpack.dpvs;
+  src = pkgs.fetchFromGitHub {
+    owner = "iqiyi";
+    repo = "dpvs";
+    rev = "v1.9.4";
+    sha256 = "sha256-PSBApG2Ix/peh2+FZxz7PjK1f+JbNmL1l6aNpEhLslY=";
+  };
   
-  # postUnpack = ''
-  #   rm -r $sourceRoot/libmoon
-  #   cp -r ${srcpack.libmoon} $sourceRoot/libmoon
-  #   chmod -R u+w $sourceRoot/libmoon
-  #
-  #   rm -r $sourceRoot/libmoon/deps/dpdk
-  #   cp -r ${srcpack.dpdk} $sourceRoot/libmoon/deps/dpdk
-  #   chmod -R u+w $sourceRoot/libmoon/deps/dpdk
-  # '';
-
-  nativeBuildInputs = [
-    # cmake
-    # ninja
-    # meson
+  nativeBuildInputs = with pkgs; [
     openssl
     python3Packages.pyelftools
-    pkgs.pkgconfig
-    pkgs.coreutils
+    pkgconfig
+    coreutils
     (writeScriptBin "git" ''
         echo ignoring git command
     '')
   ];
-  buildInputs = [
-    numactl
+  buildInputs = with pkgs; [
     luajit
 
     # dpvs uses this as a dev package to recompile its own dpdk
     dpdk
 
     # dpdk libs
-    pkgs.libnl
-    pkgs.jansson
-    pkgs.libbpf
-    pkgs.libbsd
-    pkgs.libelf
-    pkgs.libpcap
-    pkgs.numactl
-    pkgs.openssl.dev
-    pkgs.zlib
+    libnl
+    jansson
+    libbpf
+    libbsd
+    libelf
+    libpcap
+    numactl
+    openssl.dev
+    zlib
 
     # dpvs deps
-    pkgs.autoconf
-    pkgs.automake
-    pkgs.popt
+    autoconf
+    automake
+    popt
   ];
-  RTE_KERNELDIR = "${linux.dev}/lib/modules/${linux.modDirVersion}/build";
-  CXXFLAGS = "-std=gnu++14"; # libmoon->highwayhash->tbb needs <c++17
   CFLAGS = "-Wno-deprecated-declarations -Wno-address -ggdb -Og";
   PKG_CONFIG_PATH = "${dpdk}/lib/pkgconfig/";
   hardeningDisable = [ "all" ];
-  # NIX_CFLAGS_COMPILE = toString (args.NIX_CFLAGS_COMPILE or "") + " -ggdb -Og";
 
   dontConfigure = true;
 
@@ -103,18 +63,6 @@ stdenv.mkDerivation {
     substituteInPlace ./src/netif.c \
       --replace "return rss_value;" "return rss_value & (!ETH_RSS_IPV6_EX); // ignore this one feature not supported by E810"
   '';
-  # postPatch = ''
-  #   ls -la ./libmoon
-  #   patchShebangs ./libmoon/build.sh ./build.sh
-  #   substituteInPlace ./libmoon/build.sh \
-  #     --replace "./bind-interfaces.sh \''${FLAGS}" "echo skipping bind-interfaces.sh"
-  #   substituteInPlace ./libmoon/deps/dpdk/drivers/net/ice/ice_ethdev.h \
-  #     --replace '#define ICE_PKG_FILE_DEFAULT "/lib/firmware/intel/ice/ddp/ice.pkg"' \
-  #     '#define ICE_PKG_FILE_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/ice-1.3.26.0.pkg"'
-  #   substituteInPlace ./libmoon/deps/dpdk/drivers/net/ice/ice_ethdev.h \
-  #     --replace '#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "/lib/firmware/intel/ice/ddp/"' \
-  #     '#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/"'
-  # '';
 
   buildPhase = ''
     export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${dpdk}/lib/pkgconfig"
@@ -127,38 +75,6 @@ stdenv.mkDerivation {
     mkdir -p $out/share/conf
     cp -r /build/$sourceRoot/conf $out/share
   '';
-  # installPhase = ''
-  #   mkdir -p $out/bin
-  #
-  #   cp build/MoonGen $out/bin
-  #   mkdir -p $out/bin/lua
-  #   cp -r examples $out/bin
-  #   cp -r flows $out/bin
-  #   cp -r interface $out/bin
-  #   cp -r lua $out/bin
-  #   cp -r rfc2544 $out/bin
-  #   mkdir -p $out/bin/libmoon
-  #   cp -r libmoon $out/bin
-  #   mkdir -p $out/lib/libmoon
-  #   cp -r build/libmoon $out/lib/
-  #   mkdir -p $out/lib/dpdk
-  #   cp -r libmoon/deps/dpdk/x86_64-native-linux-gcc/lib $out/lib/dpdk
-  #   cp -r libmoon/deps/dpdk/x86_64-native-linux-gcc/drivers $out/lib/dpdk
-  #   mkdir -p $out/lib/luajit
-  #   cp -r libmoon/deps/luajit/usr/local/lib $out/lib/luajit
-  #   mkdir -p $out/lib/highwayhash
-  #   cp -r libmoon/deps/highwayhash/lib $out/lib/highwayhash
-  #
-  #   # autopatchelfHook?
-  #   patchelf --shrink-rpath --allowed-rpath-prefixes /nix/store $out/bin/MoonGen
-  #   patchelf --add-rpath $out/lib/libmoon $out/bin/MoonGen
-  #   patchelf --add-rpath $out/lib/libmoon/tbb_cmake_build/tbb_cmake_build_subdir_release $out/bin/MoonGen
-  #   patchelf --add-rpath $out/lib/dpdk/lib $out/bin/MoonGen
-  #   patchelf --add-rpath $out/lib/dpdk/drivers $out/bin/MoonGen
-  #   patchelf --add-rpath $out/lib/luajit/usr/local/lib $out/bin/MoonGen
-  #   patchelf --add-rpath $out/lib/highwayhash/lib $out/bin/MoonGen
-  # '';
 
-  # dontFixup = true;
   dontStrip = true;
 }

--- a/nix/dpvs.nix
+++ b/nix/dpvs.nix
@@ -31,7 +31,7 @@ let
     };
     dpdk = self.inputs.dpdk-lachnit-src;
   };
-  dpdk = self.outputs.packages.${system}.dpdk;
+  dpdk = self.outputs.packages.${system}.dpdk-dpvs;
 in
 stdenv.mkDerivation {
   pname = "dpvs";

--- a/nix/dpvs.nix
+++ b/nix/dpvs.nix
@@ -1,0 +1,197 @@
+{ self
+,stdenv
+, fetchFromGitHub
+, fetchurl
+, writeScriptBin
+, linux
+, openssl
+, tbb
+, libbsd
+, numactl
+, luajit
+, hello
+, cmake
+, ninja
+, meson
+, bash
+, gcc8Stdenv
+, libpcap
+, python3Packages
+, linux-firmware-pinned
+, system
+, pkgs
+}:
+let 
+  dpdkVersion = "21.11";
+  srcpack = {
+    dpvs = fetchFromGitHub {
+      owner = "iqiyi";
+      repo = "dpvs";
+      rev = "v1.9.4";
+      sha256 = "sha256-PSBApG2Ix/peh2+FZxz7PjK1f+JbNmL1l6aNpEhLslY=";
+    };
+    moongen = self.inputs.moongen-lachnit-src;
+    libmoon = self.inputs.libmoon-lachnit-src;
+    dpdk = self.inputs.dpdk-lachnit-src;
+    # dpdk = fetchurl {
+    #   url = "https://fast.dpdk.org/rel/dpdk-${dpdkVersion}.tar.xz";
+    #   sha256 = "sha256-HhJJm0xfzbV8g+X+GE6mvs3ffPCSiTwsXvLvsO7BLws=";
+    # };
+    #
+  };
+  dpdk = self.outputs.packages.${system}.dpdk;
+in
+stdenv.mkDerivation {
+  pname = "dpvs";
+  version = "2023-09-21";
+
+  src = srcpack.dpvs;
+  
+  postUnpack = ''
+    cp -r ${dpdk} $sourceRoot/dpdk-result
+    chmod -R u+w $sourceRoot/dpdk-result
+  '';
+  # postUnpack = ''
+  #   rm -r $sourceRoot/libmoon
+  #   cp -r ${srcpack.libmoon} $sourceRoot/libmoon
+  #   chmod -R u+w $sourceRoot/libmoon
+  #
+  #   rm -r $sourceRoot/libmoon/deps/dpdk
+  #   cp -r ${srcpack.dpdk} $sourceRoot/libmoon/deps/dpdk
+  #   chmod -R u+w $sourceRoot/libmoon/deps/dpdk
+  # '';
+
+  nativeBuildInputs = [
+    # cmake
+    # ninja
+    # meson
+    openssl
+    python3Packages.pyelftools
+    pkgs.pkgconfig
+    pkgs.coreutils
+    (writeScriptBin "git" ''
+        echo ignoring git command
+    '')
+  ];
+  buildInputs = [
+    numactl
+    luajit
+
+    # dpvs uses this as a dev package to recompile its own dpdk
+    dpdk
+
+    # dpdk libs
+    pkgs.libnl
+    pkgs.jansson
+    pkgs.libbpf
+    pkgs.libbsd
+    pkgs.libelf
+    pkgs.libpcap
+    pkgs.numactl
+    pkgs.openssl.dev
+    pkgs.zlib
+
+    # dpvs deps
+    pkgs.autoconf
+    pkgs.automake
+    pkgs.popt
+  ];
+  RTE_KERNELDIR = "${linux.dev}/lib/modules/${linux.modDirVersion}/build";
+  CXXFLAGS = "-std=gnu++14"; # libmoon->highwayhash->tbb needs <c++17
+  CFLAGS = "-Wno-deprecated-declarations -Wno-address -ggdb -Og";
+  PKG_CONFIG_PATH = "${dpdk}/lib/pkgconfig/";
+  hardeningDisable = [ "all" ];
+  # NIX_CFLAGS_COMPILE = toString (args.NIX_CFLAGS_COMPILE or "") + " -ggdb -Og";
+
+  dontConfigure = true;
+
+  postPatch = ''
+    substituteInPlace ./Makefile \
+      --replace "/bin/uname" "${pkgs.coreutils}/bin/uname"
+    substituteInPlace ./dpdk-result/include/rte_mbuf_dyn.h \
+      --replace "#include <sys/types.h>
+    " "#include <sys/types.h>
+    #include <stdint.h>
+    "
+    substituteInPlace ./src/mbuf.c \
+      --replace "#include <rte_mbuf_dyn.h>
+    " "#include <stdint.h>
+    #include <stdio.h>
+    #include <rte_compat.h>
+    #include <rte_mbuf_dyn.h>
+    "
+    substituteInPlace ./tools/ipvsadm/ipvsadm.c \
+      --replace '#include "popt.h"' '#include <popt.h>'
+    substituteInPlace ./Makefile \
+      --replace 'INSDIR  =' 'INSDIR  ?='
+    substituteInPlace ./src/netif.c \
+      --replace "return rss_value;" "return rss_value & (!ETH_RSS_IPV6_EX); // ignore this one feature not supported by E810"
+
+    # dpvs sample config crashes, if not all cores are configured. Sample config uses 9 cores.
+    substituteInPlace ./src/config.mk \
+      --replace 'DPVS_MAX_LCORE=64' 'DPVS_MAX_LCORE=9'
+    substituteInPlace ./src/ctrl.c \
+      --replace 'MSG_MAX_LCORE_SUPPORTED 64' 'MSG_MAX_LCORE_SUPPORTED 9'
+
+    substituteInPlace ./dpdk-result/lib/pkgconfig/libdpdk.pc \
+      --replace "${dpdk}" "$sourceRoot/dpdk-result"
+  '';
+  # postPatch = ''
+  #   ls -la ./libmoon
+  #   patchShebangs ./libmoon/build.sh ./build.sh
+  #   substituteInPlace ./libmoon/build.sh \
+  #     --replace "./bind-interfaces.sh \''${FLAGS}" "echo skipping bind-interfaces.sh"
+  #   substituteInPlace ./libmoon/deps/dpdk/drivers/net/ice/ice_ethdev.h \
+  #     --replace '#define ICE_PKG_FILE_DEFAULT "/lib/firmware/intel/ice/ddp/ice.pkg"' \
+  #     '#define ICE_PKG_FILE_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/ice-1.3.26.0.pkg"'
+  #   substituteInPlace ./libmoon/deps/dpdk/drivers/net/ice/ice_ethdev.h \
+  #     --replace '#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "/lib/firmware/intel/ice/ddp/"' \
+  #     '#define ICE_PKG_FILE_SEARCH_PATH_DEFAULT "${linux-firmware-pinned}/lib/firmware/intel/ice/ddp/"'
+  # '';
+
+  buildPhase = ''
+    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$sourceRoot/dpdk-result/lib/pkgconfig"
+    make DEBUG=1
+  '';
+
+  installPhase = ''
+    export INSDIR=$out/bin
+    make install
+    mkdir -p $out/share/conf
+    cp -r /build/$sourceRoot/conf $out/share
+  '';
+  # installPhase = ''
+  #   mkdir -p $out/bin
+  #
+  #   cp build/MoonGen $out/bin
+  #   mkdir -p $out/bin/lua
+  #   cp -r examples $out/bin
+  #   cp -r flows $out/bin
+  #   cp -r interface $out/bin
+  #   cp -r lua $out/bin
+  #   cp -r rfc2544 $out/bin
+  #   mkdir -p $out/bin/libmoon
+  #   cp -r libmoon $out/bin
+  #   mkdir -p $out/lib/libmoon
+  #   cp -r build/libmoon $out/lib/
+  #   mkdir -p $out/lib/dpdk
+  #   cp -r libmoon/deps/dpdk/x86_64-native-linux-gcc/lib $out/lib/dpdk
+  #   cp -r libmoon/deps/dpdk/x86_64-native-linux-gcc/drivers $out/lib/dpdk
+  #   mkdir -p $out/lib/luajit
+  #   cp -r libmoon/deps/luajit/usr/local/lib $out/lib/luajit
+  #   mkdir -p $out/lib/highwayhash
+  #   cp -r libmoon/deps/highwayhash/lib $out/lib/highwayhash
+  #
+  #   # autopatchelfHook?
+  #   patchelf --shrink-rpath --allowed-rpath-prefixes /nix/store $out/bin/MoonGen
+  #   patchelf --add-rpath $out/lib/libmoon $out/bin/MoonGen
+  #   patchelf --add-rpath $out/lib/libmoon/tbb_cmake_build/tbb_cmake_build_subdir_release $out/bin/MoonGen
+  #   patchelf --add-rpath $out/lib/dpdk/lib $out/bin/MoonGen
+  #   patchelf --add-rpath $out/lib/dpdk/drivers $out/bin/MoonGen
+  #   patchelf --add-rpath $out/lib/luajit/usr/local/lib $out/bin/MoonGen
+  #   patchelf --add-rpath $out/lib/highwayhash/lib $out/bin/MoonGen
+  # '';
+
+  # dontFixup = true;
+  dontStrip = true;
+}


### PR DESCRIPTION
 - with E810 VF (iavf) dpvs inits and starts polling
 - with E810 PF (ice) dpvs inits and start polling, but seems to use some fallback function (NETIF: dpdk_set_mc_list: rte_eth_dev_set_mc_addr_list is not supported, enable all multicast.)

`sudo ./result/bin/dpvs -c ./nix/dpvs.conf.single-nic.sample -- -l 0-8`
