### PR TITLE
Add bridge-e1000 interface type

### DIFF
--- a/test/src/autotest.py
+++ b/test/src/autotest.py
@@ -196,7 +196,7 @@ def setup_parser() -> ArgumentParser:
     run_guest_parser.add_argument('-i',
                                   '--interface',
                                   type=str,
-                                  choices=['brtap', 'macvtap',
+                                  choices=['brtap', 'brtap-e1000', 'macvtap',
                                            'vfio', 'vmux'],
                                   default='brtap',
                                   help='Test network interface type.',
@@ -273,7 +273,7 @@ def setup_parser() -> ArgumentParser:
     setup_network_parser.add_argument('-i',
                                       '--interface',
                                       type=str,
-                                      choices=['brtap', 'macvtap',
+                                      choices=['brtap', 'brtap-e1000', 'macvtap',
                                                'vfio', 'vmux'],
                                       default='brtap',
                                       help='Test network interface type.',
@@ -682,6 +682,8 @@ def _setup_network(host: Host, interface: str) -> None:
     host.modprobe_test_iface_drivers()
     if interface == 'brtap':
         host.setup_test_br_tap()
+    elif interface == 'brtap-e1000':
+        host.setup_test_br_tap(multi_queue=False)
     elif interface == 'macvtap':
         host.setup_test_macvtap()
     elif interface == 'vfio':

--- a/test/src/loadlatency.py
+++ b/test/src/loadlatency.py
@@ -31,6 +31,9 @@ class Interface(Enum):
     # connected to it via TAP device
     BRIDGE = "bridge"
 
+    # Bridge using QEMU E1000 instead of VirtIO NIC
+    BRIDGE_E1000 = "bridge-e1000"
+
     # MacVTap to physical NIC on host, and for VM additionally VirtIO NIC
     # connected to it
     MACVTAP = "macvtap"
@@ -273,6 +276,8 @@ class LoadLatencyTestGenerator(object):
                 host.setup_test_bridge()
             else:
                 host.setup_test_br_tap()
+        elif interface == Interface.BRIDGE_E1000:
+            host.setup_test_br_tap(multi_queue=False)
         elif interface == Interface.MACVTAP:
             host.setup_test_macvtap()
         elif interface in [Interface.VFIO, Interface.VMUX]:
@@ -309,6 +314,8 @@ class LoadLatencyTestGenerator(object):
         net_type = None
         if interface == Interface.BRIDGE:
             net_type = 'brtap'
+        if interface == Interface.BRIDGE_E1000:
+            net_type = 'brtap-e1000'
         elif interface == Interface.MACVTAP:
             net_type = 'macvtap'
         elif interface == Interface.VFIO:


### PR DESCRIPTION
This adds the option to use an Intel E1000 NIC instead of VirtIO by choosing "bridge-e1000" as an interface in the test config or by using "brtap-e1000" in the autotest interface (-i) argument