### PR TITLE
Integrate iperf into autotest

### DIFF
--- a/test/conf/autotest_example.cfg
+++ b/test/conf/autotest_example.cfg
@@ -38,6 +38,8 @@ test_iface_dpdk_driv=igb_uio
 test_iface_vfio_driv=vfio-pci
 # Name of the test bridge for Linux bridge/TAP interfaces.
 test_bridge=br-${common:username}1
+# IP address and netmask assigned to the bridge. Only needed for iperf
+test_bridge_ip_net=10.1.0.1/24
 # Name of the test TAP interface for Linux bridge/TAP interfaces.
 test_tap=tap-${common:username}1
 # Name of the test MacVTAP interface.
@@ -82,6 +84,8 @@ test_iface=eth1
 test_iface_addr=0000:00:07.0
 # MAC address of the guest's test interface.
 test_iface_mac=52:54:00:fa:00:60
+# IP address and netmask assigned to the guest's test interface. Only needed for iperf
+test_iface_ip_net=10.1.0.2/24
 # Default driver of the guest's test interface.
 test_iface_driv=virtio-pci
 # DPDK driver of the guest's test interface.

--- a/test/conf/tests_example.cfg
+++ b/test/conf/tests_example.cfg
@@ -11,6 +11,9 @@ home_dir = /home/${username}
 # name is not included in the output file names, so if you want to separate the
 # outputs, you need to use different output directories.
 [virtio]
+# Type of test, options are moongen and iperf,
+# iperf requires iperf reflector!
+type=moongen
 # Types of machines to test, options are host, pcvm and microvm ...
 # host means the host machine, pcvm means a virtual machine with a
 # PCI bus and microvm means a virtual machine without a PCI bus so
@@ -29,6 +32,7 @@ vhosts = false, true
 ioregionfds = false
 # reflector types to use, options are moongen and xdp ... note that only
 # possible combinations with machines are run.
+# set to iperf for iperf test type
 reflectors = xdp
 # packet generator rates to test.
 rates = 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150
@@ -46,3 +50,5 @@ cooldown = false
 accumulate = true
 # output directory for results.
 outputdir = ${home_dir}/outputs
+# iperf client command, runtime is already configured
+iperf_cmd = -c 10.1.0.2

--- a/test/src/autotest.py
+++ b/test/src/autotest.py
@@ -519,6 +519,7 @@ def create_servers(conf: ConfigParser,
             conf['host']['test_iface_dpdk_driv'],
             conf['host']['test_iface_vfio_driv'],
             conf['host']['test_bridge'],
+            conf.get('host', 'test_bridge_ip_net', fallback=None),
             conf['host']['test_tap'],
             conf['host']['test_macvtap'],
             conf['host']['vmux_path'],
@@ -542,6 +543,7 @@ def create_servers(conf: ConfigParser,
             conf['guest']['test_iface'],
             conf['guest']['test_iface_addr'],
             conf['guest']['test_iface_mac'],
+            conf.get('guest', 'test_iface_ip_net', fallback=None),
             conf['guest']['test_iface_driv'],
             conf['guest']['test_iface_dpdk_driv'],
             conf['guest']['tmux_socket'],
@@ -989,6 +991,7 @@ def test_load_lat_file(args: Namespace, conf: ConfigParser) -> None:
 
             tconf = test_conf[section]
             generator = LoadLatencyTestGenerator(
+                tconf['type'] if 'type' in tconf else 'moongen',
                 {Machine(m.strip()) for m in tconf['machines'].split(',')},
                 {Interface(i.strip()) for i in tconf['interfaces'].split(',')},
                 {q.strip() for q in tconf['qemus'].split(',')},
@@ -1004,7 +1007,8 @@ def test_load_lat_file(args: Namespace, conf: ConfigParser) -> None:
                 tconf['warmup'] == 'true',
                 tconf['cooldown'] == 'true',
                 tconf['accumulate'] == 'true',
-                tconf['outputdir']
+                tconf['outputdir'],
+                tconf['iperf_cmd'] if 'iperf_cmd' in tconf else None
             )
             generator.generate(host)
             if args.dry_run:
@@ -1032,6 +1036,7 @@ def acc_load_lat_file(args: Namespace, conf: ConfigParser) -> None:
 
             tconf = test_conf[section]
             generator = LoadLatencyTestGenerator(
+                tconf['type'] if 'type' in tconf else 'moongen',
                 {Machine(m.strip()) for m in tconf['machines'].split(',')},
                 {Interface(i.strip()) for i in tconf['interfaces'].split(',')},
                 {q.strip() for q in tconf['qemus'].split(',')},
@@ -1047,7 +1052,8 @@ def acc_load_lat_file(args: Namespace, conf: ConfigParser) -> None:
                 tconf['warmup'] == 'true',
                 tconf['cooldown'] == 'true',
                 tconf['accumulate'] == 'true',
-                tconf['outputdir']
+                tconf['outputdir'],
+                tconf['iperf_cmd'] if 'iperf_cmd' in tconf else None
             )
             generator.generate(host)
             generator.force_accumulate()

--- a/test/src/loadlatency.py
+++ b/test/src/loadlatency.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from logging import error, info, debug
+from logging import error, info, debug, warning
 from time import sleep
 from os.path import isfile, join as path_join
 from copy import deepcopy
+from typing import Optional
 
 from server import Server, Host, Guest, LoadGen
 
@@ -51,12 +52,16 @@ class Reflector(Enum):
     # XDP reflector
     XDP = "xdp"
 
+    # Iperf server, not really a reflector but it also runs in the VM
+    IPERF = "iperf"
+
 
 @dataclass
 class LoadLatencyTest(object):
     """
     Load latency test class
     """
+    test_type: str
     machine: Machine
     interface: Interface
     mac: str
@@ -71,6 +76,7 @@ class LoadLatencyTest(object):
     warmup: bool
     cooldown: bool
     outputdir: str
+    iperf_cmd: Optional[str]
 
     def test_infix(self):
         if self.machine == Machine.HOST:
@@ -89,6 +95,12 @@ class LoadLatencyTest(object):
             )
 
     def output_filepath(self, repetition: int):
+        if self.test_type == "iperf":
+            return path_join(
+                self.outputdir,
+                f"output_iperf_{self.test_infix()}_rep{repetition}.log"
+            )
+
         return path_join(
             self.outputdir,
             f"output_{self.test_infix()}_rep{repetition}.log"
@@ -104,6 +116,9 @@ class LoadLatencyTest(object):
         output_file = self.output_filepath(repetition)
         histogram_file = self.histogram_filepath(repetition)
 
+        if self.test_type == "iperf":
+            return isfile(output_file)
+
         return isfile(output_file) and isfile(histogram_file)
 
     def needed(self):
@@ -114,6 +129,7 @@ class LoadLatencyTest(object):
 
     def __str__(self):
         return ("LoadLatencyTest(" +
+                f"type={self.test_type}, " +
                 f"machine={self.machine.value}, " +
                 f"interface={self.interface.value}, " +
                 f"mac={self.mac}, " +
@@ -125,7 +141,8 @@ class LoadLatencyTest(object):
                 f"size={self.size}, " +
                 f"runtime={self.runtime}, " +
                 f"repetitions={self.repetitions}, " +
-                f"outputdir={self.outputdir})")
+                f"outputdir={self.outputdir}, " +
+                f"iperf_cmd={self.iperf_cmd})")
 
     def run(self, loadgen: LoadGen):
         info(f"Running test {self}")
@@ -137,9 +154,12 @@ class LoadLatencyTest(object):
             # warm-up
             sleep(10)
             try:
-                loadgen.run_l2_load_latency(self.mac, 0, 20,
-                                            histfile=remote_histogram_file,
-                                            outfile=remote_output_file)
+                if self.test_type != "iperf":
+                    loadgen.run_l2_load_latency(self.mac, 0, 20,
+                                                histfile=remote_histogram_file,
+                                                outfile=remote_output_file)
+                else:
+                    warning("Use --omit <time> in iperf cmd instead of warmup")
             except Exception as e:
                 error(f'Failed to run warm-up due to exception: {e}')
             sleep(25)
@@ -158,19 +178,26 @@ class LoadLatencyTest(object):
             try:
                 loadgen.exec(f'sudo rm -f {remote_output_file} ' +
                              f'{remote_histogram_file}')
-                loadgen.run_l2_load_latency(self.mac, self.rate,
-                                            self.runtime, self.size,
-                                            histfile=remote_histogram_file,
-                                            outfile=remote_output_file)
+                if self.test_type == "iperf":
+                    loadgen.run_iperf_client(self.iperf_cmd, self.runtime,
+                                             outfile=remote_output_file)
+                else:
+                    loadgen.run_l2_load_latency(self.mac, self.rate,
+                                                self.runtime, self.size,
+                                                histfile=remote_histogram_file,
+                                                outfile=remote_output_file)
             except Exception as e:
                 error(f'Failed to run test due to exception: {e}')
                 continue
 
             sleep(self.runtime + 5)
             try:
-                loadgen.wait_for_success(f'ls {remote_histogram_file}')
+                if self.test_type == "iperf":
+                    loadgen.wait_for_success(f'grep -Fxq "iperf Done." {remote_output_file}')
+                else:
+                    loadgen.wait_for_success(f'ls {remote_histogram_file}')
             except TimeoutError:
-                error('Waiting for histogram file to appear timed out')
+                error('Waiting for histogram file to appear or iperf output timed out')
                 continue
             sleep(1)
             # TODO here a tmux_exists function would come in handy
@@ -182,8 +209,11 @@ class LoadLatencyTest(object):
             # download results
             loadgen.copy_from(remote_output_file,
                               self.output_filepath(repetition))
-            loadgen.copy_from(remote_histogram_file,
-                              self.histogram_filepath(repetition))
+
+            # iPerf3 has no histogram
+            if self.test_type != "iperf":
+                loadgen.copy_from(remote_histogram_file,
+                                  self.histogram_filepath(repetition))
 
     def accumulate(self, force: bool = False):
         assert self.repetitions > 0, 'Reps must be greater than 0.'
@@ -221,6 +251,7 @@ class LoadLatencyTestGenerator(object):
     """
     Load latency test generator class
     """
+    test_type: str
     machines: set[Machine]
     interfaces: set[Interface]
     qemus: set[str]
@@ -235,12 +266,14 @@ class LoadLatencyTestGenerator(object):
     cooldown: bool
     accumulate: bool
     outputdir: str
+    iperf_cmd: Optional[str]
 
     full_test_tree: dict = field(init=False, repr=False, default=None)
     todo_test_tree: dict = field(init=False, repr=False, default=None)
 
     def __post_init__(self):
         info('Initializing test generator:')
+        info(f'  type       : {self.test_type}')
         info(f'  machines   : {set(m.value for m in self.machines)}')
         info(f'  interfaces : {set(i.value for i in self.interfaces)}')
         info(f'  qemus      : {self.qemus}')
@@ -255,9 +288,10 @@ class LoadLatencyTestGenerator(object):
         info(f'  cooldown   : {self.cooldown}')
         info(f'  accumulate : {self.accumulate}')
         info(f'  outputdir  : {self.outputdir}')
+        info(f'  iperf_cmd  : {self.iperf_cmd}')
 
     def generate(self, host: Host):
-        self.full_test_tree = self.create_test_tree(host)
+        self.full_test_tree = self.create_test_tree(host, iperf_cmd=self.iperf_cmd)
         self.todo_test_tree = self.create_needed_test_tree(self.full_test_tree)
 
     def setup_interface(self, host: Host, machine: Machine,
@@ -285,8 +319,12 @@ class LoadLatencyTestGenerator(object):
             server.bind_test_iface()
             server.setup_hugetlbfs()
             server.start_moongen_reflector()
-        else:
+        elif reflector == Reflector.XDP:
             server.start_xdp_reflector(iface)
+        elif reflector == Reflector.IPERF:
+            server.start_iperf_server()
+        else:
+            error(f"Unknown reflector {reflector}")
         sleep(5)
 
     def stop_reflector(self, server: Server, reflector: Reflector,
@@ -300,8 +338,12 @@ class LoadLatencyTestGenerator(object):
                 server.bind_device(server.test_iface_addr, 'ice')
             else:
                 server.release_test_iface()
-        else:
+        elif reflector == Reflector.XDP:
             server.stop_xdp_reflector(iface)
+        elif reflector == Reflector.IPERF:
+            server.stop_iperf_server()
+        else:
+            error(f"Unknown reflector {reflector}")
 
     def run_guest(self, host: Host, machine: Machine,
                   interface: Interface, qemu: str, vhost: bool,
@@ -325,10 +367,10 @@ class LoadLatencyTestGenerator(object):
             vhost=vhost
         )
 
-    def create_interface_test_tree(self, machine: Machine,
+    def create_interface_test_tree(self, test_type: str, machine: Machine,
                                    interface: Interface, mac: str, qemu: str,
                                    vhost: bool, ioregionfd: bool,
-                                   reflector: Reflector):
+                                   reflector: Reflector, iperf_cmd: str):
         tree = {}
         for rate in self.rates:
             tree[rate] = {}
@@ -336,6 +378,7 @@ class LoadLatencyTestGenerator(object):
                 tree[rate][size] = {}
                 for runtime in self.runtimes:
                     test = LoadLatencyTest(
+                        test_type=test_type,
                         machine=machine,
                         interface=interface,
                         mac=mac,
@@ -350,11 +393,12 @@ class LoadLatencyTestGenerator(object):
                         warmup=self.warmup,
                         cooldown=self.cooldown,
                         outputdir=self.outputdir,
+                        iperf_cmd=iperf_cmd,
                     )
                     tree[rate][size][runtime] = test
         return tree
 
-    def create_test_tree(self, host: Host):
+    def create_test_tree(self, host: Host, iperf_cmd: Optional[str] = None):
         tree = {}
         count = 0
         interface_test_count = \
@@ -378,13 +422,15 @@ class LoadLatencyTestGenerator(object):
                         continue
                     tree[m][i][q][v][io][r] = \
                         self.create_interface_test_tree(
+                            test_type=self.test_type,
                             machine=m,
                             interface=i,
                             mac=mac,
                             qemu=q,
                             vhost=v,
                             ioregionfd=io,
-                            reflector=r
+                            reflector=r,
+                            iperf_cmd=iperf_cmd
                         )
                     count += interface_test_count
         # vm part
@@ -417,13 +463,15 @@ class LoadLatencyTestGenerator(object):
                                     continue
                                 tree[m][i][q][v][io][r] = \
                                     self.create_interface_test_tree(
+                                        test_type=self.test_type,
                                         machine=m,
                                         interface=i,
                                         mac=mac,
                                         qemu=qemu,
                                         vhost=v,
                                         ioregionfd=io,
-                                        reflector=r
+                                        reflector=r,
+                                        iperf_cmd=iperf_cmd
                                     )
                                 count += interface_test_count
         info(f'Generated {count} tests')
@@ -541,6 +589,10 @@ class LoadLatencyTestGenerator(object):
 
                                 debug("Detecting guest test interface")
                                 guest.detect_test_iface()
+
+                                if guest.test_iface_ip_net:
+                                    debug('Assigning IP to test iface in guest')
+                                    guest.setup_test_iface_ip_net()
 
                             for reflector, rtree in ftree.items():
                                 debug(f"Starting reflector {reflector.value}")


### PR DESCRIPTION
First chaotic integration of iperf into autotest.
All new config parameters are optional to not break existing configs, tests will fall back to moongen test type by default.

The integration currently has a couple of problems:

- Loadgen and VM must be on same host
- Autotest will still setup things required for moongen, such as DPDK
- iPerf measurements are a lot slower than they should be, might be an issue with the bridge being also bound to a physical NIC

The existing autotest code isn't really made to support new testing tools.
iPerf test code and configuration should probably be separated to not cause a mess of optional parameters and null values.