### PR TITLE
meson: add option to not build the e1000 emulator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('vmux', ['c' ,'cpp'],
   version : '0.1',
   default_options : ['warning_level=3', 'cpp_std=c++20', 'default_library=static'])
 
+e1000_emu = get_option('e1000_emu')
 dont_build_libnic_emu = get_option('dont_build_libnic_emu')
 
 #incdir = include_directories('deps/libvfio-user/include')
@@ -58,13 +59,19 @@ dpdk_link_args = [
 libvfio_user = subproject('libvfio-user')
 libvfio_user_dep = libvfio_user.get_variable('libvfio_user_dep')
 
-if dont_build_libnic_emu
-  nic_emu_dep = declare_dependency(
-    link_args : ['-L./libnic_emu.a', '-lnic_emu'],
-    )
-else 
-  nic_emu = subproject('nic-emu')
-  nic_emu_dep = nic_emu.get_variable('nic_emu_dep')
+if e1000_emu
+  if dont_build_libnic_emu
+    nic_emu_dep = declare_dependency(
+      link_args : ['-L./libnic_emu.a', '-lnic_emu'],
+      )
+  else 
+    nic_emu = subproject('nic-emu')
+    nic_emu_dep = nic_emu.get_variable('nic_emu_dep')
+  endif
+  add_project_arguments('-DBUILD_E1000_EMU', language : 'c')
+  add_project_arguments('-DBUILD_E1000_EMU', language : 'cpp')
+else
+  nic_emu_dep = dependency('', required: false)
 endif
 
 sources = files()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
+option('e1000_emu', type : 'boolean', value : true, description : 'Link against libnic_emu to support e1000 emulation.')
 option('dont_build_libnic_emu', type : 'boolean', value : false, description : 'Skip libnic_emu subproject build. Instead expect artifacts in path.')

--- a/src/interrupts/accurate.hpp
+++ b/src/interrupts/accurate.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "devices/vmux-device.hpp"
-#include "nic-emu.hpp"
 #include "src/drivers/tap.hpp"
 #include "util.hpp"
 #include <bits/types/struct_itimerspec.h>

--- a/src/interrupts/global.cpp
+++ b/src/interrupts/global.cpp
@@ -1,6 +1,6 @@
 #include <memory>
 #include <algorithm>
-#include "devices/e1000.hpp"
+#include "interrupts/interface.hpp"
 #include "interrupts/global.hpp"
 
 GlobalInterrupts::GlobalInterrupts(int nr_threads) {

--- a/src/interrupts/qemu.hpp
+++ b/src/interrupts/qemu.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "devices/vmux-device.hpp"
-#include "nic-emu.hpp"
 #include "src/drivers/tap.hpp"
 #include "util.hpp"
 #include <bits/types/struct_itimerspec.h>

--- a/src/interrupts/simbricks.hpp
+++ b/src/interrupts/simbricks.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "devices/vmux-device.hpp"
-#include "nic-emu.hpp"
 #include "src/drivers/tap.hpp"
 #include "util.hpp"
 #include <bits/types/struct_itimerspec.h>


### PR DESCRIPTION
This is useful if one does not want to build libnic-emu at all.