### PR TITLE
qemu-vfio-user: update to v9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,6 +291,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1737569578,
+        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1714640452,
@@ -338,6 +354,7 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-2111": "nixpkgs-2111",
         "nixpkgs-2211": "nixpkgs-2211",
+        "nixpkgs-2411": "nixpkgs-2411",
         "qemu-ioregionfd-src": "qemu-ioregionfd-src",
         "xdp-reflector-src": "xdp-reflector-src"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-2211.url = "github:NixOS/nixpkgs/nixos-22.11";
     nixpkgs-2111.url = "github:NixOS/nixpkgs/nixos-21.11";
+    nixpkgs-2411.url = "github:NixOS/nixpkgs/nixos-24.11";
 
     flake-utils.url = "github:numtide/flake-utils";
     
@@ -84,6 +85,7 @@
     pkgs = nixpkgs.legacyPackages.${system};
     pkgs2211 = args.nixpkgs-2211.legacyPackages.${system};
     pkgs2111 = args.nixpkgs-2111.legacyPackages.${system};
+    pkgs2411 = args.nixpkgs-2411.legacyPackages.${system};
     flakepkgs = self.packages.${system};
     selfpkgs = self.packages.${system};
     # make-disk-image = import (pkgs.path + "/nixos/lib/make-disk-image.nix");
@@ -172,7 +174,7 @@
       #patched qemu
       qemu = pkgs.callPackage ./nix/qemu-libvfio.nix {
         # needs a nixpkgs with qemu ~7.1.0 for patches to apply.
-        inherit pkgs2211;
+        inherit pkgs2411;
       };
 
       qemu-ioregionfd = pkgs2211.qemu.overrideAttrs ( new: old: {

--- a/nix/qemu-libvfio.nix
+++ b/nix/qemu-libvfio.nix
@@ -1,14 +1,80 @@
-{ pkgs2211 }:
-with pkgs2211;
-qemu_full.overrideAttrs ( new: old: {
-  src = fetchFromGitHub {
-    owner = "oracle";
+{ pkgs2411 }:
+with pkgs2411;
+qemu_full.overrideAttrs ( new: old: rec {
+  # src = fetchFromGitHub {
+  #   owner = "oracle";
+  #   repo = "qemu";
+  #   rev = "b3b53245edbd399eb3ba1655d509478c76d37a8e";
+  #   hash = "sha256-kCX2ByuJxERLY2nHjPndVoo7TQm1j4qrpLjRcs42HU4=";
+  #   fetchSubmodules = true;
+  # };
+  src = fetchFromGitHub {# based on jlevon/qemu master.vfio-user 23.01.2025
+    owner = "vmuxio";
     repo = "qemu";
-    rev = "b3b53245edbd399eb3ba1655d509478c76d37a8e";
-    hash = "sha256-kCX2ByuJxERLY2nHjPndVoo7TQm1j4qrpLjRcs42HU4=";
+    rev = "cd7fccdd25f452d8b49d3e474a18425579dba4d8";
+    hash = "sha256-GYW3teWlkPQRUMtYV1iVZbyjSUlwDln2XoWlsRlQJqw=";
     fetchSubmodules = true;
   };
   version = "7.1.5";
+
+    #when updating qemu, sync these with what is specified in qemu/subprojects/*.wrap
+  libvfio-user-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "libvfio-user";
+    rev = "0b28d205572c80b568a1003db2c8f37ca333e4d7"; # upstream master 09.06.2022
+    hash = "sha256-V05nnJbz8Us28N7nXvQYbj66LO4WbVBm6EO+sCjhhG8=";
+    fetchSubmodules = true;
+  };
+    dtc-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "dtc";
+    rev = "b6910bec11614980a21e46fbccc35934b671bd81";
+    hash = "sha256-gx9LG3U9etWhPxm7Ox7rOu9X5272qGeHqZtOe68zFs4=";
+    fetchSubmodules = true;
+  };
+  keycodemapdb-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "keycodemapdb";
+    rev = "f5772a62ec52591ff6870b7e8ef32482371f22c6";
+    hash = "sha256-EQrnBAXQhllbVCHpOsgREzYGncMUPEIoWFGnjo+hrH4=";
+    fetchSubmodules = true;
+  };
+  bsf3-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "berkeley-softfloat-3";
+    rev = "b64af41c3276f97f0e181920400ee056b9c88037";
+    hash = "sha256-Yflpx+mjU8mD5biClNpdmon24EHg4aWBZszbOur5VEA=";
+    fetchSubmodules = true;
+  };
+  btf3-src = pkgs.fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "berkeley-testfloat-3";
+    rev = "40619cbb3bf32872df8c53cc457039229428a263";
+    hash = "sha256-EBz1uYnjehCtJqrSFzERH23N5ELZU3gGM26JnsGFcWg=";
+    fetchSubmodules = true;
+  };
+
+  # emulate meson subproject dependency management
+  postUnpack = ''
+    cp -r ${libvfio-user-src} $sourceRoot/subprojects/libvfio-user
+    chmod -R u+w $sourceRoot/subprojects/libvfio-user
+
+    cp -r ${dtc-src} $sourceRoot/subprojects/dtc
+    chmod -R u+w $sourceRoot/subprojects/dtc
+
+    cp -r ${keycodemapdb-src} $sourceRoot/subprojects/keycodemapdb
+    chmod -R u+w $sourceRoot/subprojects/keycodemapdb
+
+    cp -r ${bsf3-src} $sourceRoot/subprojects/berkeley-softfloat-3
+    chmod -R u+w $sourceRoot/subprojects/berkeley-softfloat-3
+    cp $sourceRoot/subprojects/packagefiles/berkeley-softfloat-3/* $sourceRoot/subprojects/berkeley-softfloat-3
+
+    cp -r ${btf3-src} $sourceRoot/subprojects/berkeley-testfloat-3
+    chmod -R u+w $sourceRoot/subprojects/berkeley-testfloat-3
+    cp $sourceRoot/subprojects/packagefiles/berkeley-testfloat-3/* $sourceRoot/subprojects/berkeley-testfloat-3
+  '';
+
+
   buildInputs = [ libndctl ] ++ old.buildInputs;
   nativeBuildInputs = [ json_c cmocka ] ++ old.nativeBuildInputs;
   configureFlags = old.configureFlags ++ [
@@ -39,7 +105,7 @@ qemu_full.overrideAttrs ( new: old: {
     "--disable-smartcard"
     "--disable-usb-redir"
     "--enable-virtfs"
-    "--disable-virtiofsd"
+    # "--disable-virtiofsd"
     "--disable-xen"
     "--disable-xen-pci-passthrough"
     "--disable-xkbcommon"
@@ -55,8 +121,10 @@ qemu_full.overrideAttrs ( new: old: {
     "--disable-parallels"
   ] ++ [ "--enable-vfio-user-server"];
   patches = old.patches ++ [
-    ./print.patch
-    ./0001-qemu-hva2gpa.patch
-    ./0001-qemu-dma_read.patch
+    # ./print.patch
+    # ./0001-qemu-hva2gpa.patch
+    # ./0001-qemu-dma_read.patch
   ];
+  NIX_CFLAGS_COMPILE = "-Wno-dangling-pointer"; # libvfio-user contains a dangling poitner
+  hardeningDisable = [ "all" ];
 })


### PR DESCRIPTION
this qemu version should have libvfio-user patches as well as new support for 40G intel NIC-like device emulation.

Seems to work with our tests